### PR TITLE
Add `Hotwire*` Fragments and remove `BridgeDestination` interface

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/bridge/Bridge.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/Bridge.kt
@@ -18,7 +18,7 @@ class Bridge internal constructor(webView: WebView) {
 
     internal val webView: WebView? get() = webViewRef.get()
     internal var repository = Repository()
-    internal var delegate: BridgeDelegate<*>? = null
+    internal var delegate: BridgeDelegate? = null
 
     init {
         // Use a weak reference in case the WebView is no longer being

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponent.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponent.kt
@@ -2,9 +2,9 @@ package dev.hotwire.core.bridge
 
 import dev.hotwire.core.logging.logWarning
 
-abstract class BridgeComponent<in D : BridgeDestination>(
+abstract class BridgeComponent(
     val name: String,
-    private val delegate: BridgeDelegate<D>
+    private val delegate: BridgeDelegate
 ) {
     private val receivedMessages = hashMapOf<String, Message>()
 

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentFactory.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentFactory.kt
@@ -1,8 +1,8 @@
 package dev.hotwire.core.bridge
 
-class BridgeComponentFactory<D : BridgeDestination, out C : BridgeComponent<D>> constructor(
+class BridgeComponentFactory<out C : BridgeComponent> constructor(
     val name: String,
-    private val creator: (name: String, delegate: BridgeDelegate<D>) -> C
+    private val creator: (name: String, delegate: BridgeDelegate) -> C
 ) {
-    fun create(delegate: BridgeDelegate<D>) = creator(name, delegate)
+    fun create(delegate: BridgeDelegate) = creator(name, delegate)
 }

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeDestination.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeDestination.kt
@@ -1,5 +1,0 @@
-package dev.hotwire.core.bridge
-
-interface BridgeDestination {
-    fun bridgeWebViewIsReady(): Boolean
-}

--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -1,16 +1,25 @@
 package dev.hotwire.core.config
 
+import dev.hotwire.core.bridge.BridgeComponent
 import dev.hotwire.core.bridge.BridgeComponentFactory
 
 object Hotwire {
+    internal var registeredBridgeComponentFactories:
+        List<BridgeComponentFactory<BridgeComponent>> = emptyList()
+        private set
+
     val config: HotwireConfig = HotwireConfig()
+
+    fun registerBridgeComponentFactories(factories: List<BridgeComponentFactory<BridgeComponent>>) {
+        registeredBridgeComponentFactories = factories
+    }
 
     /**
      * Provides a standard substring to be included in your WebView's user agent
      * to identify itself as a Hotwire Native app.
      */
-    fun userAgentSubstring(componentFactories: List<BridgeComponentFactory<*, *>>): String {
-        val components = componentFactories.joinToString(" ") { it.name }
+    fun userAgentSubstring(): String {
+        val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
         return "Turbo Native Android; bridge-components: [$components];"
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireBottomSheetFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireBottomSheetFragment.kt
@@ -1,0 +1,5 @@
+package dev.hotwire.core.navigation.fragments
+
+import dev.hotwire.core.turbo.fragments.TurboBottomSheetDialogFragment
+
+abstract class HotwireBottomSheetFragment : TurboBottomSheetDialogFragment()

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireFragment.kt
@@ -1,0 +1,5 @@
+package dev.hotwire.core.navigation.fragments
+
+import dev.hotwire.core.turbo.fragments.TurboFragment
+
+abstract class HotwireFragment : TurboFragment()

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireWebBottomSheetFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireWebBottomSheetFragment.kt
@@ -1,0 +1,46 @@
+package dev.hotwire.core.navigation.fragments
+
+import android.os.Bundle
+import android.view.View
+import dev.hotwire.core.bridge.BridgeDelegate
+import dev.hotwire.core.config.Hotwire
+import dev.hotwire.core.turbo.fragments.TurboWebBottomSheetDialogFragment
+import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
+import dev.hotwire.core.turbo.views.TurboWebView
+
+@TurboNavGraphDestination(uri = "turbo://fragment/web/modal/sheet")
+open class HotwireWebBottomSheetFragment : TurboWebBottomSheetDialogFragment() {
+    private val bridgeDelegate by lazy {
+        BridgeDelegate(
+            location = location,
+            destination = this,
+            componentFactories = Hotwire.registeredBridgeComponentFactories
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
+    }
+
+    override fun onColdBootPageStarted(location: String) {
+        bridgeDelegate.onColdBootPageStarted()
+    }
+
+    override fun onColdBootPageCompleted(location: String) {
+        bridgeDelegate.onColdBootPageCompleted()
+    }
+
+    override fun onWebViewAttached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewAttached(webView)
+    }
+
+    override fun onWebViewDetached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewDetached()
+    }
+}

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireWebFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/fragments/HotwireWebFragment.kt
@@ -1,0 +1,46 @@
+package dev.hotwire.core.navigation.fragments
+
+import android.os.Bundle
+import android.view.View
+import dev.hotwire.core.bridge.BridgeDelegate
+import dev.hotwire.core.config.Hotwire
+import dev.hotwire.core.turbo.fragments.TurboWebFragment
+import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
+import dev.hotwire.core.turbo.views.TurboWebView
+
+@TurboNavGraphDestination(uri = "turbo://fragment/web")
+open class HotwireWebFragment : TurboWebFragment() {
+    private val bridgeDelegate by lazy {
+        BridgeDelegate(
+            location = location,
+            destination = this,
+            componentFactories = Hotwire.registeredBridgeComponentFactories
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
+    }
+
+    override fun onColdBootPageStarted(location: String) {
+        bridgeDelegate.onColdBootPageStarted()
+    }
+
+    override fun onColdBootPageCompleted(location: String) {
+        bridgeDelegate.onColdBootPageCompleted()
+    }
+
+    override fun onWebViewAttached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewAttached(webView)
+    }
+
+    override fun onWebViewDetached(webView: TurboWebView) {
+        bridgeDelegate.onWebViewDetached()
+    }
+}

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/fragments/TurboWebBottomSheetDialogFragment.kt
@@ -21,7 +21,6 @@ import dev.hotwire.core.turbo.views.TurboWebChromeClient
  *
  * For native bottom sheet fragments, refer to [TurboBottomSheetDialogFragment].
  */
-@Suppress("unused")
 abstract class TurboWebBottomSheetDialogFragment : TurboBottomSheetDialogFragment(),
     TurboWebFragmentCallback {
     private lateinit var webDelegate: TurboWebFragmentDelegate

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/BridgeComponentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/BridgeComponentTest.kt
@@ -11,7 +11,7 @@ import org.junit.Test
 
 class BridgeComponentTest {
     private lateinit var component: TestData.OneBridgeComponent
-    private val delegate: BridgeDelegate<TestData.AppBridgeDestination> = mock()
+    private val delegate: BridgeDelegate = mock()
 
     private val message = Message(
         id = "1",

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/BridgeDelegateTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/BridgeDelegateTest.kt
@@ -7,6 +7,8 @@ import com.nhaarman.mockito_kotlin.eq
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.never
 import com.nhaarman.mockito_kotlin.whenever
+import dev.hotwire.core.turbo.nav.TurboNavDestination
+import dev.hotwire.core.turbo.session.TurboSession
 import org.junit.Assert.*
 import org.junit.Before
 import org.junit.Rule
@@ -14,10 +16,12 @@ import org.junit.Test
 import org.mockito.Mockito.verify
 
 class BridgeDelegateTest {
-    private lateinit var delegate: BridgeDelegate<TestData.AppBridgeDestination>
+    private lateinit var delegate: BridgeDelegate
     private lateinit var lifecycleOwner: TestLifecycleOwner
     private val bridge: Bridge = mock()
     private val webView: WebView = mock()
+    private val destination: TurboNavDestination = mock()
+    private val session: TurboSession = mock()
 
     private val factories = listOf(
         BridgeComponentFactory("one", TestData::OneBridgeComponent),
@@ -31,11 +35,13 @@ class BridgeDelegateTest {
     @Before
     fun setup() {
         whenever(bridge.webView).thenReturn(webView)
+        whenever(destination.session).thenReturn(session)
+        whenever(session.isReady).thenReturn(true)
         Bridge.initialize(bridge)
 
         delegate = BridgeDelegate(
             location = "https://37signals.com",
-            destination = TestData.AppBridgeDestination(),
+            destination = destination,
             componentFactories = factories
         )
         delegate.bridge = bridge

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/BridgeTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/BridgeTest.kt
@@ -16,7 +16,7 @@ class BridgeTest {
     private val webView: WebView = mock()
     private val context: Context = mock()
     private val repository: Repository = mock()
-    private val delegate: BridgeDelegate<TestData.AppBridgeDestination> = mock()
+    private val delegate: BridgeDelegate = mock()
 
     @Before
     fun setup() {

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/TestData.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/TestData.kt
@@ -1,6 +1,11 @@
 package dev.hotwire.core.bridge
 
+import dev.hotwire.core.turbo.nav.TurboNavDestination
+import org.mockito.Mockito.mock
+
 object TestData {
+    private val mockNavDestination: TurboNavDestination = mock()
+
     val componentFactories = listOf(
         BridgeComponentFactory("one", TestData::OneBridgeComponent),
         BridgeComponentFactory("two", TestData::TwoBridgeComponent)
@@ -8,22 +13,18 @@ object TestData {
 
     val bridgeDelegate = BridgeDelegate(
         location = "https://37signals.com",
-        destination = AppBridgeDestination(),
+        destination = mockNavDestination,
         componentFactories = componentFactories
     )
 
-    class AppBridgeDestination : BridgeDestination {
-        override fun bridgeWebViewIsReady() = true
-    }
-
     abstract class AppBridgeComponent(
         name: String,
-        delegate: BridgeDelegate<AppBridgeDestination>
-    ) : BridgeComponent<AppBridgeDestination>(name, delegate)
+        delegate: BridgeDelegate
+    ) : BridgeComponent(name, delegate)
 
     class OneBridgeComponent(
         name: String,
-        delegate: BridgeDelegate<AppBridgeDestination>
+        delegate: BridgeDelegate
     ) : AppBridgeComponent(name, delegate) {
         var onStartCalled = false
         var onStopCalled = false
@@ -45,7 +46,7 @@ object TestData {
 
     class TwoBridgeComponent(
         name: String,
-        delegate: BridgeDelegate<AppBridgeDestination>
+        delegate: BridgeDelegate
     ) : AppBridgeComponent(name, delegate) {
         override fun onReceive(message: Message) {}
     }

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -12,7 +12,9 @@ class UserAgentTest {
             BridgeComponentFactory("two", TestData::TwoBridgeComponent)
         )
 
-        val userAgentSubstring = Hotwire.userAgentSubstring(factories)
+        Hotwire.registerBridgeComponentFactories(factories)
+
+        val userAgentSubstring = Hotwire.userAgentSubstring()
         assertTrue(userAgentSubstring.endsWith("bridge-components: [one two];"))
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/base/NavDestination.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/base/NavDestination.kt
@@ -7,7 +7,6 @@ import androidx.browser.customtabs.CustomTabsIntent
 import androidx.browser.customtabs.CustomTabsIntent.SHARE_STATE_ON
 import androidx.navigation.NavOptions
 import androidx.navigation.navOptions
-import dev.hotwire.core.bridge.BridgeDestination
 import dev.hotwire.core.turbo.config.TurboPathConfigurationProperties
 import dev.hotwire.core.turbo.config.context
 import dev.hotwire.core.turbo.nav.TurboNavDestination
@@ -15,7 +14,7 @@ import dev.hotwire.core.turbo.nav.TurboNavPresentationContext.MODAL
 import dev.hotwire.demo.R
 import dev.hotwire.demo.util.BASE_URL
 
-interface NavDestination : TurboNavDestination, BridgeDestination {
+interface NavDestination : TurboNavDestination {
     val menuProgress: MenuItem?
         get() = toolbarForNavigation()?.menu?.findItem(R.id.menu_progress)
 
@@ -37,10 +36,6 @@ interface NavDestination : TurboNavDestination, BridgeDestination {
             MODAL -> slideAnimation()
             else -> super.getNavigationOptions(newLocation, newPathProperties)
         }
-    }
-
-    override fun bridgeWebViewIsReady(): Boolean {
-        return session.isReady
     }
 
     private fun isNavigable(location: String): Boolean {

--- a/demo/src/main/kotlin/dev/hotwire/demo/bridge/BridgeComponentFactories.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/bridge/BridgeComponentFactories.kt
@@ -1,9 +1,0 @@
-package dev.hotwire.demo.bridge
-
-import dev.hotwire.core.bridge.BridgeComponentFactory
-
-val bridgeComponentFactories = listOf(
-    BridgeComponentFactory("form", ::FormComponent),
-    BridgeComponentFactory("menu", ::MenuComponent),
-    BridgeComponentFactory("overflow-menu", ::OverflowMenuComponent)
-)

--- a/demo/src/main/kotlin/dev/hotwire/demo/bridge/FormComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/bridge/FormComponent.kt
@@ -8,10 +8,9 @@ import androidx.appcompat.widget.Toolbar
 import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.BridgeComponent
 import dev.hotwire.core.bridge.BridgeDelegate
+import dev.hotwire.core.bridge.Message
 import dev.hotwire.demo.R
 import dev.hotwire.demo.databinding.FormComponentSubmitBinding
-import dev.hotwire.core.bridge.Message
-import dev.hotwire.demo.base.NavDestination
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -21,8 +20,8 @@ import kotlinx.serialization.Serializable
  */
 class FormComponent(
     name: String,
-    private val delegate: BridgeDelegate<NavDestination>
-) : BridgeComponent<NavDestination>(name, delegate) {
+    private val delegate: BridgeDelegate
+) : BridgeComponent(name, delegate) {
 
     private val submitButtonItemId = 37
     private var submitMenuItem: MenuItem? = null

--- a/demo/src/main/kotlin/dev/hotwire/demo/bridge/MenuComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/bridge/MenuComponent.kt
@@ -7,9 +7,8 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import dev.hotwire.core.bridge.BridgeComponent
 import dev.hotwire.core.bridge.BridgeDelegate
-import dev.hotwire.demo.databinding.MenuComponentBottomSheetBinding
 import dev.hotwire.core.bridge.Message
-import dev.hotwire.demo.base.NavDestination
+import dev.hotwire.demo.databinding.MenuComponentBottomSheetBinding
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -19,8 +18,8 @@ import kotlinx.serialization.Serializable
  */
 class MenuComponent(
     name: String,
-    private val delegate: BridgeDelegate<NavDestination>
-) : BridgeComponent<NavDestination>(name, delegate) {
+    private val delegate: BridgeDelegate
+) : BridgeComponent(name, delegate) {
 
     private val fragment: Fragment
         get() = delegate.destination.fragment

--- a/demo/src/main/kotlin/dev/hotwire/demo/bridge/OverflowMenuComponent.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/bridge/OverflowMenuComponent.kt
@@ -17,8 +17,8 @@ import kotlinx.serialization.Serializable
  */
 class OverflowMenuComponent(
     name: String,
-    private val delegate: BridgeDelegate<NavDestination>
-) : BridgeComponent<NavDestination>(name, delegate) {
+    private val delegate: BridgeDelegate
+) : BridgeComponent(name, delegate) {
 
     private val fragment: Fragment
         get() = delegate.destination.fragment

--- a/demo/src/main/kotlin/dev/hotwire/demo/features/imageviewer/ImageViewerFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/features/imageviewer/ImageViewerFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import com.bumptech.glide.Glide
+import dev.hotwire.core.navigation.fragments.HotwireFragment
 import dev.hotwire.core.turbo.fragments.TurboFragment
 import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
 import dev.hotwire.core.turbo.util.displayBackButtonAsCloseIcon
@@ -13,7 +14,7 @@ import dev.hotwire.demo.R
 import dev.hotwire.demo.base.NavDestination
 
 @TurboNavGraphDestination(uri = "turbo://fragment/image_viewer")
-class ImageViewerFragment : TurboFragment(), NavDestination {
+class ImageViewerFragment : HotwireFragment(), NavDestination {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_image_viewer, container, false)
     }

--- a/demo/src/main/kotlin/dev/hotwire/demo/features/numbers/NumberBottomSheetFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/features/numbers/NumberBottomSheetFragment.kt
@@ -6,14 +6,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import com.google.android.material.textview.MaterialTextView
-import dev.hotwire.core.turbo.fragments.TurboBottomSheetDialogFragment
+import dev.hotwire.core.navigation.fragments.HotwireBottomSheetFragment
 import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
 import dev.hotwire.demo.R
-import dev.hotwire.demo.util.description
 import dev.hotwire.demo.base.NavDestination
+import dev.hotwire.demo.util.description
 
 @TurboNavGraphDestination(uri = "turbo://fragment/numbers/sheet")
-class NumberBottomSheetFragment : TurboBottomSheetDialogFragment(), NavDestination {
+class NumberBottomSheetFragment : HotwireBottomSheetFragment(), NavDestination {
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         return inflater.inflate(R.layout.fragment_number_bottom_sheet, container, false)
     }

--- a/demo/src/main/kotlin/dev/hotwire/demo/features/numbers/NumbersFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/features/numbers/NumbersFragment.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import dev.hotwire.core.navigation.fragments.HotwireFragment
 import dev.hotwire.core.turbo.fragments.TurboFragment
 import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
 import dev.hotwire.demo.R
@@ -13,7 +14,7 @@ import dev.hotwire.demo.util.NUMBERS_URL
 import dev.hotwire.demo.base.NavDestination
 
 @TurboNavGraphDestination(uri = "turbo://fragment/numbers")
-class NumbersFragment : TurboFragment(), NavDestination, NumbersFragmentCallback {
+class NumbersFragment : HotwireFragment(), NavDestination, NumbersFragmentCallback {
     private val numbersAdapter = NumbersAdapter(this)
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {

--- a/demo/src/main/kotlin/dev/hotwire/demo/features/web/WebBottomSheetFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/features/web/WebBottomSheetFragment.kt
@@ -2,13 +2,14 @@ package dev.hotwire.demo.features.web
 
 import android.os.Bundle
 import android.view.View
+import dev.hotwire.core.navigation.fragments.HotwireWebBottomSheetFragment
 import dev.hotwire.core.turbo.fragments.TurboWebBottomSheetDialogFragment
 import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
 import dev.hotwire.demo.R
 import dev.hotwire.demo.base.NavDestination
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web/modal/sheet")
-class WebBottomSheetFragment : TurboWebBottomSheetDialogFragment(), NavDestination {
+class WebBottomSheetFragment : HotwireWebBottomSheetFragment(), NavDestination {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupMenu()

--- a/demo/src/main/kotlin/dev/hotwire/demo/features/web/WebFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/features/web/WebFragment.kt
@@ -2,54 +2,21 @@ package dev.hotwire.demo.features.web
 
 import android.os.Bundle
 import android.view.View
-import dev.hotwire.core.bridge.BridgeDelegate
+import dev.hotwire.core.navigation.fragments.HotwireWebFragment
 import dev.hotwire.core.turbo.errors.HttpError
 import dev.hotwire.core.turbo.errors.TurboVisitError
-import dev.hotwire.core.turbo.fragments.TurboWebFragment
 import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
-import dev.hotwire.core.turbo.views.TurboWebView
 import dev.hotwire.core.turbo.visit.TurboVisitAction.REPLACE
 import dev.hotwire.core.turbo.visit.TurboVisitOptions
 import dev.hotwire.demo.R
 import dev.hotwire.demo.base.NavDestination
-import dev.hotwire.demo.bridge.bridgeComponentFactories
 import dev.hotwire.demo.util.SIGN_IN_URL
 
 @TurboNavGraphDestination(uri = "turbo://fragment/web")
-open class WebFragment : TurboWebFragment(), NavDestination {
-    private val bridgeDelegate by lazy {
-        BridgeDelegate(
-            location = location,
-            destination = this,
-            componentFactories =  bridgeComponentFactories
-        )
-    }
-
+open class WebFragment : HotwireWebFragment(), NavDestination {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         setupMenu()
-        viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
-    }
-
-    override fun onColdBootPageStarted(location: String) {
-        bridgeDelegate.onColdBootPageStarted()
-    }
-
-    override fun onColdBootPageCompleted(location: String) {
-        bridgeDelegate.onColdBootPageCompleted()
-    }
-
-    override fun onWebViewAttached(webView: TurboWebView) {
-        bridgeDelegate.onWebViewAttached(webView)
-    }
-
-    override fun onWebViewDetached(webView: TurboWebView) {
-        bridgeDelegate.onWebViewDetached()
     }
 
     override fun onFormSubmissionStarted(location: String) {

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -4,26 +4,38 @@ import android.os.Bundle
 import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import dev.hotwire.core.BuildConfig
+import dev.hotwire.core.bridge.BridgeComponentFactory
 import dev.hotwire.core.bridge.KotlinXJsonConverter
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.activities.TurboActivity
 import dev.hotwire.core.turbo.delegates.TurboActivityDelegate
 import dev.hotwire.demo.R
+import dev.hotwire.demo.bridge.FormComponent
+import dev.hotwire.demo.bridge.MenuComponent
+import dev.hotwire.demo.bridge.OverflowMenuComponent
 
 class MainActivity : AppCompatActivity(), TurboActivity {
     override lateinit var delegate: TurboActivityDelegate
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
 
-        delegate = TurboActivityDelegate(this, R.id.main_nav_host)
         configApp()
+        setContentView(R.layout.activity_main)
+        delegate = TurboActivityDelegate(this, R.id.main_nav_host)
     }
 
     private fun configApp() {
         Hotwire.config.jsonConverter = KotlinXJsonConverter()
 
+        // Register bridge components
+        Hotwire.registerBridgeComponentFactories(listOf(
+            BridgeComponentFactory("form", ::FormComponent),
+            BridgeComponentFactory("menu", ::MenuComponent),
+            BridgeComponentFactory("overflow-menu", ::OverflowMenuComponent)
+        ))
+
+        // Enable debugging
         if (BuildConfig.DEBUG) {
             Hotwire.config.debugLoggingEnabled = true
             WebView.setWebContentsDebuggingEnabled(true)

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
@@ -1,12 +1,11 @@
 package dev.hotwire.demo.main
 
+import android.webkit.WebView
 import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.Bridge
+import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import dev.hotwire.core.turbo.session.TurboSessionNavHostFragment
-import dev.hotwire.demo.util.HOME_URL
-import dev.hotwire.demo.util.customUserAgent
-import dev.hotwire.demo.util.initDayNightTheme
 import dev.hotwire.demo.features.imageviewer.ImageViewerFragment
 import dev.hotwire.demo.features.numbers.NumberBottomSheetFragment
 import dev.hotwire.demo.features.numbers.NumbersFragment
@@ -14,6 +13,8 @@ import dev.hotwire.demo.features.web.WebBottomSheetFragment
 import dev.hotwire.demo.features.web.WebFragment
 import dev.hotwire.demo.features.web.WebHomeFragment
 import dev.hotwire.demo.features.web.WebModalFragment
+import dev.hotwire.demo.util.HOME_URL
+import dev.hotwire.demo.util.initDayNightTheme
 import kotlin.reflect.KClass
 
 @Suppress("unused")
@@ -48,4 +49,10 @@ class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
         // Initialize Strada bridge with new WebView instance
         Bridge.initialize(session.webView)
     }
+
+    private val WebView.customUserAgent: String
+        get() {
+            val substring = Hotwire.userAgentSubstring()
+            return "$substring ${settings.userAgentString}"
+        }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/util/Extensions.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/util/Extensions.kt
@@ -6,9 +6,7 @@ import android.os.Build
 import android.webkit.WebView
 import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewFeature
-import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.config.TurboPathConfigurationProperties
-import dev.hotwire.demo.bridge.bridgeComponentFactories
 
 val TurboPathConfigurationProperties.description: String?
     get() = get("description")
@@ -28,12 +26,6 @@ fun WebView.initDayNightTheme() {
         }
     }
 }
-
-val WebView.customUserAgent: String
-    get() {
-        val substring = Hotwire.userAgentSubstring(bridgeComponentFactories)
-        return "$substring ${settings.userAgentString}"
-    }
 
 private fun isNightModeEnabled(context: Context): Boolean {
     val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK


### PR DESCRIPTION
This PR:

1. Removes the `BridgeDestination` interface, which nicely removes all the generics from the public `BridgeComponent` interface.
2. Adds the following "glue" fragments:
    - `HotwireFragment`
    - `HotwireWebFragment`
    - `HotwireBottomSheetFragment`
    - `HotwireWebBottomSheetFragment`