### PR TITLE
Add a new Hotwire.config.userAgent configuration option

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -13,13 +13,4 @@ object Hotwire {
     fun registerBridgeComponentFactories(factories: List<BridgeComponentFactory<BridgeComponent>>) {
         registeredBridgeComponentFactories = factories
     }
-
-    /**
-     * Provides a standard substring to be included in your WebView's user agent
-     * to identify itself as a Hotwire Native app.
-     */
-    fun userAgentSubstring(): String {
-        val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
-        return "Turbo Native Android; bridge-components: [$components];"
-    }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -21,4 +21,24 @@ class HotwireConfig internal constructor() {
             field = value
             TurboHttpClient.reset()
         }
+
+    /**
+     * Provides a standard substring to be included in your WebView's user agent
+     * to identify itself as a Hotwire Native app.
+     *
+     * Important: Ensure that you've registered your bridge components before
+     * calling this so the bridge component names are included in your user agent.
+     */
+    fun userAgentSubstring(): String {
+        val components = Hotwire.registeredBridgeComponentFactories.joinToString(" ") { it.name }
+        return "Turbo Native Android; bridge-components: [$components];"
+    }
+
+    /**
+     * Set a custom user agent for every WebView instance.
+     *
+     * Important: Include `Hotwire.userAgentSubstring()` as part of your
+     * custom user agent for compatibility with your server.
+     */
+    var userAgent: String = userAgentSubstring()
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/views/TurboWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/views/TurboWebView.kt
@@ -9,6 +9,7 @@ import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.MATCH_PARENT
 import androidx.webkit.WebViewCompat
 import com.google.gson.GsonBuilder
+import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.util.contentFromAsset
 import dev.hotwire.core.turbo.util.runOnUiThread
 import dev.hotwire.core.turbo.util.toJson
@@ -29,6 +30,7 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         id = View.generateViewId()
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
+        settings.userAgentString = "${Hotwire.config.userAgent} ${settings.userAgentString}"
         settings.setSupportMultipleWindows(true)
         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
     }

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.core.bridge
 
 import dev.hotwire.core.config.Hotwire
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
@@ -14,7 +15,21 @@ class UserAgentTest {
 
         Hotwire.registerBridgeComponentFactories(factories)
 
-        val userAgentSubstring = Hotwire.userAgentSubstring()
-        assertTrue(userAgentSubstring.endsWith("bridge-components: [one two];"))
+        val userAgentSubstring = Hotwire.config.userAgentSubstring()
+        assertEquals(userAgentSubstring, "Turbo Native Android; bridge-components: [one two];")
+    }
+
+    @Test
+    fun userAgent() {
+        val factories = listOf(
+            BridgeComponentFactory("one", TestData::OneBridgeComponent),
+            BridgeComponentFactory("two", TestData::TwoBridgeComponent)
+        )
+
+        Hotwire.registerBridgeComponentFactories(factories)
+        Hotwire.config.userAgent = "Test; ${Hotwire.config.userAgentSubstring()}"
+        val userAgent = Hotwire.config.userAgent
+
+        assertEquals(userAgent, "Test; Turbo Native Android; bridge-components: [one two];")
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -26,14 +26,16 @@ class MainActivity : AppCompatActivity(), TurboActivity {
     }
 
     private fun configApp() {
-        Hotwire.config.jsonConverter = KotlinXJsonConverter()
-
         // Register bridge components
         Hotwire.registerBridgeComponentFactories(listOf(
             BridgeComponentFactory("form", ::FormComponent),
             BridgeComponentFactory("menu", ::MenuComponent),
             BridgeComponentFactory("overflow-menu", ::OverflowMenuComponent)
         ))
+
+        // Set configuration options
+        Hotwire.config.jsonConverter = KotlinXJsonConverter()
+        Hotwire.config.userAgent = "Hotwire Demo; ${Hotwire.config.userAgentSubstring()}"
 
         // Enable debugging
         if (BuildConfig.DEBUG) {

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
@@ -1,9 +1,7 @@
 package dev.hotwire.demo.main
 
-import android.webkit.WebView
 import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.Bridge
-import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import dev.hotwire.core.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.demo.features.imageviewer.ImageViewerFragment
@@ -43,16 +41,9 @@ class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
         super.onSessionCreated()
 
         // Configure WebView
-        session.webView.settings.userAgentString = session.webView.customUserAgent
         session.webView.initDayNightTheme()
 
         // Initialize Strada bridge with new WebView instance
         Bridge.initialize(session.webView)
     }
-
-    private val WebView.customUserAgent: String
-        get() {
-            val substring = Hotwire.userAgentSubstring()
-            return "$substring ${settings.userAgentString}"
-        }
 }


### PR DESCRIPTION
You can now set a global user-agent configuration option to automatically set the user-agent for  every WebView instance:
```kotlin
Hotwire.config.userAgent = "My App Name; ${Hotwire.config.userAgentSubstring()}"
```