### PR TITLE
Add a new `Hotwire.config.webViewDebuggingEnabled` configuration option

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -1,5 +1,6 @@
 package dev.hotwire.core.config
 
+import android.webkit.WebView
 import dev.hotwire.core.bridge.StradaJsonConverter
 import dev.hotwire.core.turbo.http.TurboHttpClient
 
@@ -15,11 +16,24 @@ class HotwireConfig internal constructor() {
      * Enables/disables debug logging. This should be disabled in production environments.
      * Disabled by default.
      *
+     * Important: You should not enable debug logging in production release builds.
      */
     var debugLoggingEnabled = false
         set(value) {
             field = value
             TurboHttpClient.reset()
+        }
+
+    /**
+     * Enables/disables debugging of web contents loaded into WebViews.
+     * Disabled by default.
+     *
+     * Important: You should not enable debugging in production release builds.
+     */
+    var webViewDebuggingEnabled = false
+        set(value) {
+            field = value
+            WebView.setWebContentsDebuggingEnabled(value)
         }
 
     /**

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -28,8 +28,8 @@ class UserAgentTest {
 
         Hotwire.registerBridgeComponentFactories(factories)
         Hotwire.config.userAgent = "Test; ${Hotwire.config.userAgentSubstring()}"
-        val userAgent = Hotwire.config.userAgent
 
+        val userAgent = Hotwire.config.userAgent
         assertEquals(userAgent, "Test; Turbo Native Android; bridge-components: [one two];")
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -1,7 +1,6 @@
 package dev.hotwire.demo.main
 
 import android.os.Bundle
-import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import dev.hotwire.core.BuildConfig
 import dev.hotwire.core.bridge.BridgeComponentFactory
@@ -36,11 +35,7 @@ class MainActivity : AppCompatActivity(), TurboActivity {
         // Set configuration options
         Hotwire.config.jsonConverter = KotlinXJsonConverter()
         Hotwire.config.userAgent = "Hotwire Demo; ${Hotwire.config.userAgentSubstring()}"
-
-        // Enable debugging
-        if (BuildConfig.DEBUG) {
-            Hotwire.config.debugLoggingEnabled = true
-            WebView.setWebContentsDebuggingEnabled(true)
-        }
+        Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG
+        Hotwire.config.webViewDebuggingEnabled = BuildConfig.DEBUG
     }
 }


### PR DESCRIPTION
Instead of calling the platform `WebView.setWebContentsDebuggingEnabled(value)` directly, there's now a new configuration option available:
```kotlin
Hotwire.config.webViewDebuggingEnabled = true
```