### PR TITLE
Add a new `Hotwire.config.pathConfigurationLocation` configuration option

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -2,6 +2,7 @@ package dev.hotwire.core.config
 
 import android.webkit.WebView
 import dev.hotwire.core.bridge.StradaJsonConverter
+import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import dev.hotwire.core.turbo.http.TurboHttpClient
 
 class HotwireConfig internal constructor() {
@@ -35,6 +36,12 @@ class HotwireConfig internal constructor() {
             field = value
             WebView.setWebContentsDebuggingEnabled(value)
         }
+
+    /**
+     * The location of your [TurboPathConfiguration] JSON file(s) to configure
+     * navigation rules.
+     */
+    var pathConfigurationLocation = TurboPathConfiguration.Location()
 
     /**
      * Provides a standard substring to be included in your WebView's user agent

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/TurboSessionNavHostFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/TurboSessionNavHostFragment.kt
@@ -6,7 +6,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
-import dev.hotwire.core.turbo.config.TurboPathConfiguration
+import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.nav.TurboNavDestination
 import dev.hotwire.core.turbo.nav.TurboNavGraphBuilder
 import dev.hotwire.core.turbo.views.TurboWebView
@@ -23,12 +23,6 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
      * The url of a starting location when your app starts up.
      */
     abstract val startLocation: String
-
-    /**
-     * The location of your [TurboPathConfiguration] JSON file(s) to configure
-     * navigation rules.
-     */
-    abstract val pathConfigurationLocation: TurboPathConfiguration.Location
 
     /**
      * A list of registered fragments that can be navigated to. Every possible
@@ -67,7 +61,7 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
      * WebView instance is required.
      */
     open fun onSessionCreated() {
-        session.pathConfiguration.load(pathConfigurationLocation)
+        session.pathConfiguration.load(Hotwire.config.pathConfigurationLocation)
     }
 
     /**

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -7,6 +7,7 @@ import dev.hotwire.core.bridge.BridgeComponentFactory
 import dev.hotwire.core.bridge.KotlinXJsonConverter
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.activities.TurboActivity
+import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import dev.hotwire.core.turbo.delegates.TurboActivityDelegate
 import dev.hotwire.demo.R
 import dev.hotwire.demo.bridge.FormComponent
@@ -37,5 +38,8 @@ class MainActivity : AppCompatActivity(), TurboActivity {
         Hotwire.config.userAgent = "Hotwire Demo; ${Hotwire.config.userAgentSubstring()}"
         Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG
         Hotwire.config.webViewDebuggingEnabled = BuildConfig.DEBUG
+        Hotwire.config.pathConfigurationLocation = TurboPathConfiguration.Location(
+            assetFilePath = "json/configuration.json"
+        )
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
@@ -2,7 +2,6 @@ package dev.hotwire.demo.main
 
 import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.Bridge
-import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import dev.hotwire.core.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.demo.features.imageviewer.ImageViewerFragment
 import dev.hotwire.demo.features.numbers.NumberBottomSheetFragment
@@ -30,11 +29,6 @@ class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
             NumbersFragment::class,
             NumberBottomSheetFragment::class,
             ImageViewerFragment::class
-        )
-
-    override val pathConfigurationLocation: TurboPathConfiguration.Location
-        get() = TurboPathConfiguration.Location(
-            assetFilePath = "json/configuration.json"
         )
 
     override fun onSessionCreated() {


### PR DESCRIPTION
This adds a new `Hotwire.config.pathConfigurationLocation` configuration option to set the location of your path configuration files. To use:

```kotlin
Hotwire.config.pathConfigurationLocation = TurboPathConfiguration.Location(
    assetFilePath = "json/configuration.json"
)
```