### PR TITLE
Register fragment destinations through `Hotwire.registerFragmentDestinations()`

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -1,16 +1,33 @@
 package dev.hotwire.core.config
 
+import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.BridgeComponent
 import dev.hotwire.core.bridge.BridgeComponentFactory
+import kotlin.reflect.KClass
 
 object Hotwire {
     internal var registeredBridgeComponentFactories:
         List<BridgeComponentFactory<BridgeComponent>> = emptyList()
         private set
 
+    internal var registeredFragmentDestinations: List<KClass<out Fragment>> = emptyList()
+        private set
+
     val config: HotwireConfig = HotwireConfig()
 
+    /**
+     * Register bridge component factories that the app supports. Every possible bridge
+     * component must be provided here.
+     */
     fun registerBridgeComponentFactories(factories: List<BridgeComponentFactory<BridgeComponent>>) {
         registeredBridgeComponentFactories = factories
+    }
+
+    /**
+     * Register fragment destinations that can be navigated to. Every possible
+     * destination must be provided here.
+     */
+    fun registerFragmentDestinations(destinations: List<KClass<out Fragment>>) {
+        registeredFragmentDestinations = destinations
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/TurboSessionNavHostFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/TurboSessionNavHostFragment.kt
@@ -3,7 +3,6 @@ package dev.hotwire.core.turbo.session
 import android.content.Context
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import dev.hotwire.core.config.Hotwire
@@ -23,12 +22,6 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
      * The url of a starting location when your app starts up.
      */
     abstract val startLocation: String
-
-    /**
-     * A list of registered fragments that can be navigated to. Every possible
-     * [dev.hotwire.core.turbo.fragments.TurboFragment] destination must be listed here.
-     */
-    abstract val registeredFragments: List<KClass<out Fragment>>
 
     /**
      * A list of registered Activities that can be navigated to. This is optional.
@@ -107,7 +100,7 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
                 navController = findNavController()
             ).build(
                 registeredActivities = registeredActivities,
-                registeredFragments = registeredFragments
+                registeredFragments = Hotwire.registeredFragmentDestinations
             )
         }
     }

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -13,6 +13,13 @@ import dev.hotwire.demo.R
 import dev.hotwire.demo.bridge.FormComponent
 import dev.hotwire.demo.bridge.MenuComponent
 import dev.hotwire.demo.bridge.OverflowMenuComponent
+import dev.hotwire.demo.features.imageviewer.ImageViewerFragment
+import dev.hotwire.demo.features.numbers.NumberBottomSheetFragment
+import dev.hotwire.demo.features.numbers.NumbersFragment
+import dev.hotwire.demo.features.web.WebBottomSheetFragment
+import dev.hotwire.demo.features.web.WebFragment
+import dev.hotwire.demo.features.web.WebHomeFragment
+import dev.hotwire.demo.features.web.WebModalFragment
 
 class MainActivity : AppCompatActivity(), TurboActivity {
     override lateinit var delegate: TurboActivityDelegate
@@ -26,6 +33,17 @@ class MainActivity : AppCompatActivity(), TurboActivity {
     }
 
     private fun configApp() {
+        // Register fragment destinations
+        Hotwire.registerFragmentDestinations(listOf(
+            WebFragment::class,
+            WebHomeFragment::class,
+            WebModalFragment::class,
+            WebBottomSheetFragment::class,
+            NumbersFragment::class,
+            NumberBottomSheetFragment::class,
+            ImageViewerFragment::class
+        ))
+
         // Register bridge components
         Hotwire.registerBridgeComponentFactories(listOf(
             BridgeComponentFactory("form", ::FormComponent),

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
@@ -1,35 +1,15 @@
 package dev.hotwire.demo.main
 
-import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.Bridge
 import dev.hotwire.core.turbo.session.TurboSessionNavHostFragment
-import dev.hotwire.demo.features.imageviewer.ImageViewerFragment
-import dev.hotwire.demo.features.numbers.NumberBottomSheetFragment
-import dev.hotwire.demo.features.numbers.NumbersFragment
-import dev.hotwire.demo.features.web.WebBottomSheetFragment
-import dev.hotwire.demo.features.web.WebFragment
-import dev.hotwire.demo.features.web.WebHomeFragment
-import dev.hotwire.demo.features.web.WebModalFragment
 import dev.hotwire.demo.util.HOME_URL
 import dev.hotwire.demo.util.initDayNightTheme
-import kotlin.reflect.KClass
 
 @Suppress("unused")
 class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
     override val sessionName = "main"
 
     override val startLocation = HOME_URL
-
-    override val registeredFragments: List<KClass<out Fragment>>
-        get() = listOf(
-            WebFragment::class,
-            WebHomeFragment::class,
-            WebModalFragment::class,
-            WebBottomSheetFragment::class,
-            NumbersFragment::class,
-            NumberBottomSheetFragment::class,
-            ImageViewerFragment::class
-        )
 
     override fun onSessionCreated() {
         super.onSessionCreated()


### PR DESCRIPTION
The way to register `Fragment` destinations is now through `Hotwire.registerFragmentDestinations()`. To use:

```kotlin
Hotwire.registerFragmentDestinations(listOf(
    WebFragment::class,
    WebHomeFragment::class,
    WebModalFragment::class
))
```