### PR TITLE
Move day/night WebView theming support into the library

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/views/TurboWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/views/TurboWebView.kt
@@ -2,12 +2,16 @@ package dev.hotwire.core.turbo.views
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.res.Configuration
+import android.os.Build
 import android.util.AttributeSet
 import android.view.View
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.MATCH_PARENT
+import androidx.webkit.WebSettingsCompat
 import androidx.webkit.WebViewCompat
+import androidx.webkit.WebViewFeature
 import com.google.gson.GsonBuilder
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.util.contentFromAsset
@@ -33,6 +37,7 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
         settings.userAgentString = "${Hotwire.config.userAgent} ${settings.userAgentString}"
         settings.setSupportMultipleWindows(true)
         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
+        initDayNightTheming()
     }
 
     /**
@@ -87,5 +92,29 @@ open class TurboWebView @JvmOverloads constructor(context: Context, attrs: Attri
 
     private fun encodeArguments(vararg args: Any): String? {
         return args.joinToString(",") { gson.toJson(it) }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun initDayNightTheming() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
+                WebSettingsCompat.setForceDarkStrategy(
+                    settings,
+                    WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY
+                )
+            }
+
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                when (isNightModeEnabled(context)) {
+                    true -> WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_ON)
+                    else -> WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_AUTO)
+                }
+            }
+        }
+    }
+
+    private fun isNightModeEnabled(context: Context): Boolean {
+        val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+        return currentNightMode == Configuration.UI_MODE_NIGHT_YES
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainSessionNavHostFragment.kt
@@ -2,18 +2,10 @@ package dev.hotwire.demo.main
 
 import dev.hotwire.core.turbo.session.TurboSessionNavHostFragment
 import dev.hotwire.demo.util.HOME_URL
-import dev.hotwire.demo.util.initDayNightTheme
 
 @Suppress("unused")
 class MainSessionNavHostFragment : TurboSessionNavHostFragment() {
     override val sessionName = "main"
 
     override val startLocation = HOME_URL
-
-    override fun onSessionCreated() {
-        super.onSessionCreated()
-
-        // Configure WebView
-        session.webView.initDayNightTheme()
-    }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/util/Extensions.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/util/Extensions.kt
@@ -1,33 +1,6 @@
 package dev.hotwire.demo.util
 
-import android.content.Context
-import android.content.res.Configuration
-import android.os.Build
-import android.webkit.WebView
-import androidx.webkit.WebSettingsCompat
-import androidx.webkit.WebViewFeature
 import dev.hotwire.core.turbo.config.TurboPathConfigurationProperties
 
 val TurboPathConfigurationProperties.description: String?
     get() = get("description")
-
-@Suppress("DEPRECATION")
-fun WebView.initDayNightTheme() {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK_STRATEGY)) {
-            WebSettingsCompat.setForceDarkStrategy(settings, WebSettingsCompat.DARK_STRATEGY_WEB_THEME_DARKENING_ONLY)
-        }
-
-        if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-            when (isNightModeEnabled(context)) {
-                true -> WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_ON)
-                else -> WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_AUTO)
-            }
-        }
-    }
-}
-
-private fun isNightModeEnabled(context: Context): Boolean {
-    val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-    return currentNightMode == Configuration.UI_MODE_NIGHT_YES
-}


### PR DESCRIPTION
This moves proper day/night theming support for `WebView` content into the library, so apps don't have to worry about this detail.