### PR TITLE
Drop support for allowing Activities as registered destinations

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/nav/TurboNavGraphBuilder.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/nav/TurboNavGraphBuilder.kt
@@ -1,7 +1,6 @@
 package dev.hotwire.core.turbo.nav
 
 import android.net.Uri
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.net.toUri
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
@@ -22,12 +21,6 @@ internal class TurboNavGraphBuilder(
     private val navController: NavController,
     private val pathConfiguration: TurboPathConfiguration
 ) {
-    private data class ActivityDestination(
-        val route: String,
-        val uri: Uri,
-        val kClass: KClass<out AppCompatActivity>
-    )
-
     private data class FragmentDestination(
         val route: String,
         val uri: Uri,
@@ -35,18 +28,9 @@ internal class TurboNavGraphBuilder(
     )
 
     fun build(
-        registeredActivities: List<KClass<out AppCompatActivity>>,
         registeredFragments: List<KClass<out Fragment>>
     ): NavGraph {
         var currentRoute = 1
-
-        val activityDestinations = registeredActivities.map {
-            ActivityDestination(
-                route = currentRoute.also { currentRoute++ }.toString(),
-                uri = it.turboAnnotation().uri.toUri(),
-                kClass = it
-            )
-        }
 
         val fragmentDestinations = registeredFragments.map {
             FragmentDestination(
@@ -57,7 +41,6 @@ internal class TurboNavGraphBuilder(
         }
 
         return createGraph(
-            activityDestinations,
             fragmentDestinations,
             fragmentDestinations.startDestination().route
         )
@@ -65,18 +48,10 @@ internal class TurboNavGraphBuilder(
 
     @Suppress("UNCHECKED_CAST")
     private fun createGraph(
-        activityDestinations: List<ActivityDestination>,
         fragmentDestinations: List<FragmentDestination>,
         startDestinationRoute: String
     ): NavGraph {
         return navController.createGraph(startDestination = startDestinationRoute) {
-            activityDestinations.forEach {
-                activity(it.route) {
-                    activityClass = it.kClass
-                    deepLink(it.uri.toString())
-                }
-            }
-
             fragmentDestinations.withoutDialogs().forEach {
                 fragment(it.route, it.kClass) {
                     deepLink(it.uri.toString())

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/TurboSessionNavHostFragment.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/TurboSessionNavHostFragment.kt
@@ -10,7 +10,6 @@ import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.nav.TurboNavDestination
 import dev.hotwire.core.turbo.nav.TurboNavGraphBuilder
 import dev.hotwire.core.turbo.views.TurboWebView
-import kotlin.reflect.KClass
 
 abstract class TurboSessionNavHostFragment : NavHostFragment() {
     /**
@@ -23,11 +22,6 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
      * The url of a starting location when your app starts up.
      */
     abstract val startLocation: String
-
-    /**
-     * A list of registered Activities that can be navigated to. This is optional.
-     */
-    open val registeredActivities: List<KClass<out AppCompatActivity>> = emptyList()
 
     /**
      * The [TurboSession] instance that is shared with all destinations that are
@@ -105,7 +99,6 @@ abstract class TurboSessionNavHostFragment : NavHostFragment() {
                 pathConfiguration = session.pathConfiguration,
                 navController = findNavController()
             ).build(
-                registeredActivities = registeredActivities,
                 registeredFragments = Hotwire.registeredFragmentDestinations
             )
         }


### PR DESCRIPTION
Going forward, if you want to support multiple Activities in your app, you'll need to manually navigate between them using system APIs. Single-`Activity` app architecture is what most apps should use — but even if not, the existing `Activity` navigation support was minimal at best, and it's best to cut off support now.