### PR TITLE
Default fragment destination

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.fragment.app.Fragment
 import dev.hotwire.core.bridge.BridgeComponent
 import dev.hotwire.core.bridge.BridgeComponentFactory
-import dev.hotwire.core.navigation.routing.BrowserRoute
+import dev.hotwire.core.navigation.fragments.HotwireWebBottomSheetFragment
+import dev.hotwire.core.navigation.fragments.HotwireWebFragment
 import dev.hotwire.core.navigation.routing.AppNavigationRoute
+import dev.hotwire.core.navigation.routing.BrowserRoute
 import dev.hotwire.core.navigation.routing.Router
 import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import kotlin.reflect.KClass
@@ -15,7 +17,11 @@ object Hotwire {
         List<BridgeComponentFactory<BridgeComponent>> = emptyList()
         private set
 
-    internal var registeredFragmentDestinations: List<KClass<out Fragment>> = emptyList()
+    internal var registeredFragmentDestinations:
+        List<KClass<out Fragment>> = listOf(
+            HotwireWebFragment::class,
+            HotwireWebBottomSheetFragment::class
+        )
         private set
 
     internal var router = Router(listOf(
@@ -58,6 +64,13 @@ object Hotwire {
     fun registerBridgeComponents(factories: List<BridgeComponentFactory<BridgeComponent>>) {
         registeredBridgeComponentFactories = factories
     }
+
+    /**
+     * The default fragment destination for web requests. If you have not
+     * loaded a path configuration with a matching rule and a `uri` available
+     * for all possible paths, this destination will be used as the default.
+     */
+    var defaultFragmentDestination: KClass<out Fragment> = HotwireWebFragment::class
 
     /**
      * Register fragment destinations that can be navigated to. Every possible

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/TurboPathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/TurboPathConfiguration.kt
@@ -3,7 +3,10 @@ package dev.hotwire.core.turbo.config
 import android.annotation.SuppressLint
 import android.content.Context
 import android.net.Uri
+import androidx.core.net.toUri
 import com.google.gson.annotations.SerializedName
+import dev.hotwire.core.config.Hotwire
+import dev.hotwire.core.turbo.nav.TurboNavGraphDestination
 import dev.hotwire.core.turbo.nav.TurboNavPresentation
 import dev.hotwire.core.turbo.nav.TurboNavPresentationContext
 import dev.hotwire.core.turbo.nav.TurboNavQueryStringPresentation
@@ -131,10 +134,11 @@ val TurboPathConfigurationProperties.context: TurboNavPresentationContext
     }
 
 val TurboPathConfigurationProperties.uri: Uri
-    get() = Uri.parse(get("uri"))
+    get() = get("uri")?.toUri() ?:
+        TurboNavGraphDestination.from(Hotwire.defaultFragmentDestination).uri.toUri()
 
 val TurboPathConfigurationProperties.fallbackUri: Uri?
-    get() = get("fallback_uri")?.let { Uri.parse(it) }
+    get() = get("fallback_uri")?.toUri()
 
 val TurboPathConfigurationProperties.title: String?
     get() = get("title")

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/nav/TurboNavGraphBuilder.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/nav/TurboNavGraphBuilder.kt
@@ -13,7 +13,6 @@ import dev.hotwire.core.turbo.config.TurboPathConfiguration
 import dev.hotwire.core.turbo.config.uri
 import java.util.UUID
 import kotlin.reflect.KClass
-import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.isSubclassOf
 
 internal class TurboNavGraphBuilder(
@@ -35,7 +34,7 @@ internal class TurboNavGraphBuilder(
         val fragmentDestinations = registeredFragments.map {
             FragmentDestination(
                 route = currentRoute.also { currentRoute++ }.toString(),
-                uri = it.turboAnnotation().uri.toUri(),
+                uri = TurboNavGraphDestination.from(it).uri.toUri(),
                 kClass = it
             )
         }
@@ -91,12 +90,6 @@ internal class TurboNavGraphBuilder(
         val startDestinationUri = pathConfiguration.properties(startLocation).uri
         return requireNotNull(firstOrNull { it.uri == startDestinationUri }) {
             "A start Fragment destination was not found for uri: $startDestinationUri"
-        }
-    }
-
-    private fun KClass<out Any>.turboAnnotation(): TurboNavGraphDestination {
-        return requireNotNull(findAnnotation()) {
-            "A TurboNavGraphDestination annotation is required for the destination: ${this.simpleName}"
         }
     }
 

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/nav/TurboNavGraphDestination.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/nav/TurboNavGraphDestination.kt
@@ -1,5 +1,8 @@
 package dev.hotwire.core.turbo.nav
 
+import kotlin.reflect.KClass
+import kotlin.reflect.full.findAnnotation
+
 /**
  * Annotation for each Fragment that will be registered as a navigation destination.
  *
@@ -14,4 +17,12 @@ package dev.hotwire.core.turbo.nav
 @MustBeDocumented
 annotation class TurboNavGraphDestination(
     val uri: String
-)
+) {
+    companion object {
+        internal fun from(klass: KClass<out Any>): TurboNavGraphDestination {
+            return requireNotNull(klass.findAnnotation()) {
+                "A TurboNavGraphDestination annotation is required for the destination: ${klass.simpleName}"
+            }
+        }
+    }
+}

--- a/demo/src/main/assets/json/configuration.json
+++ b/demo/src/main/assets/json/configuration.json
@@ -59,6 +59,7 @@
         "/numbers/[0-9]+$"
       ],
       "properties": {
+        "context": "modal",
         "uri": "turbo://fragment/numbers/sheet",
         "title": "Number",
         "description": "This is a native bottom sheet fragment"

--- a/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
@@ -41,6 +41,9 @@ class DemoApplication : Application() {
             )
         )
 
+        // Set the default fragment destination
+        Hotwire.defaultFragmentDestination = WebFragment::class
+
         // Register fragment destinations
         Hotwire.registerFragmentDestinations(listOf(
             WebFragment::class,


### PR DESCRIPTION
This adds the ability to set a default fragment destination. If you have not loaded a path configuration with a matching rule and a `uri` available for all possible paths, this destination will be used as the default. To set a default:

```kotlin
Hotwire.defaultFragmentDestination = WebFragment::class
```

Additionally, the library's `HotwireWebFragment` destination is set as the initial default, making it possible to use the library without registering your own fragment destinations or setting up a path configuration file. It's much easier to spin up a new app and then further customize as you go.