### PR TITLE
Rename route.perform() -> route.handle()

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/navigation/routing/AppNavigationRoute.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/routing/AppNavigationRoute.kt
@@ -12,7 +12,7 @@ class AppNavigationRoute : Router.Route {
         return appUrl.toUri().host == location.toUri().host
     }
 
-    override fun perform(location: String, activity: AppCompatActivity) {
+    override fun handle(location: String, activity: AppCompatActivity) {
         // No-op
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/routing/BrowserRoute.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/routing/BrowserRoute.kt
@@ -15,7 +15,7 @@ class BrowserRoute : Router.Route {
         return appUrl.toUri().host != location.toUri().host
     }
 
-    override fun perform(location: String, activity: AppCompatActivity) {
+    override fun handle(location: String, activity: AppCompatActivity) {
         val intent = Intent(Intent.ACTION_VIEW, location.toUri())
 
         try {

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/routing/BrowserTabRoute.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/routing/BrowserTabRoute.kt
@@ -16,7 +16,7 @@ class BrowserTabRoute : Router.Route {
         return appUrl.toUri().host != location.toUri().host
     }
 
-    override fun perform(location: String, activity: AppCompatActivity) {
+    override fun handle(location: String, activity: AppCompatActivity) {
         val color = activity.colorFromThemeAttr(R.attr.colorSurface)
         val colorParams = CustomTabColorSchemeParams.Builder()
             .setToolbarColor(color)

--- a/core/src/main/kotlin/dev/hotwire/core/navigation/routing/Router.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/navigation/routing/Router.kt
@@ -41,10 +41,10 @@ class Router(private val routes: List<Route>) {
         fun matches(location: String): Boolean
 
         /**
-         * Perform custom routing behavior when a match is found. For example,
+         * Handle custom routing behavior when a match is found. For example,
          * open an external browser or app for external domain urls.
          */
-        fun perform(location: String, activity: AppCompatActivity)
+        fun handle(location: String, activity: AppCompatActivity)
     }
 
     enum class RouteResult {
@@ -67,7 +67,7 @@ class Router(private val routes: List<Route>) {
                     "location" to location
                 ))
 
-                route.perform(location, activity)
+                route.handle(location, activity)
                 return route.result
             }
         }


### PR DESCRIPTION
This improves the route interface naming so it more closely aligns with iOS.