### PR TITLE
Present better looking Material web dialogs

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/views/TurboWebChromeClient.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/views/TurboWebChromeClient.kt
@@ -2,14 +2,53 @@ package dev.hotwire.core.turbo.views
 
 import android.net.Uri
 import android.os.Message
+import android.webkit.JsResult
 import android.webkit.ValueCallback
 import android.webkit.WebChromeClient
 import android.webkit.WebView
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dev.hotwire.core.R
 import dev.hotwire.core.turbo.session.Session
 import dev.hotwire.core.turbo.util.toJson
 import dev.hotwire.core.turbo.visit.VisitOptions
 
 open class TurboWebChromeClient(val session: Session) : WebChromeClient() {
+    override fun onJsAlert(view: WebView?, url: String?, message: String?, result: JsResult?): Boolean {
+        val context = view?.context ?: return false
+
+        MaterialAlertDialogBuilder(context)
+            .setMessage(message)
+            .setPositiveButton(context.getString(R.string.turbo_dialog_ok)) { dialog, _ ->
+                dialog.cancel()
+                result?.confirm()
+            }
+            .setCancelable(false)
+            .create()
+            .show()
+
+        return true
+    }
+
+    override fun onJsConfirm(view: WebView?, url: String?, message: String?, result: JsResult?): Boolean {
+        val context = view?.context ?: return false
+
+        MaterialAlertDialogBuilder(context)
+            .setMessage(message)
+            .setNegativeButton(context.getString(R.string.turbo_dialog_cancel)) { dialog, _ ->
+                dialog.cancel()
+                result?.cancel()
+            }
+            .setPositiveButton(context.getString(R.string.turbo_dialog_ok)) { dialog, _ ->
+                dialog.cancel()
+                result?.confirm()
+            }
+            .setCancelable(false)
+            .create()
+            .show()
+
+        return true
+    }
+
     override fun onShowFileChooser(
         webView: WebView,
         filePathCallback: ValueCallback<Array<Uri>>,

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="turbo_error_message">Error loading page</string>
     <string name="turbo_file_chooser_select">Select file</string>
     <string name="turbo_file_chooser_select_multiple">Select file(s)</string>
+    <string name="turbo_dialog_ok">OK</string>
+    <string name="turbo_dialog_cancel">Cancel</string>
 </resources>


### PR DESCRIPTION
This presents nice looking (and styleable) dialogs based on your app's Material theme instead of the default `WebView` dialogs, which includes an undesirable title: **The page at "https://example.com" says:**.

Addresses the dialog example in: https://github.com/hotwired/hotwire-native-android/pull/28

cc @joemasilotti 