### PR TITLE
Remove the `screenshots_enabled` setting flag

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -145,6 +145,3 @@ val PathConfigurationProperties.title: String?
 
 val PathConfigurationProperties.pullToRefreshEnabled: Boolean
     get() = get("pull_to_refresh_enabled")?.toBoolean() ?: false
-
-val PathConfigurationSettings.screenshotsEnabled: Boolean
-    get() = get("screenshots_enabled")?.toBoolean() ?: true

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/delegates/TurboWebFragmentDelegate.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/delegates/TurboWebFragmentDelegate.kt
@@ -373,8 +373,6 @@ internal class TurboWebFragmentDelegate(
     }
 
     private fun screenshotView() {
-        if (!session.screenshotsEnabled) return
-
         turboView?.let {
             screenshot = it.createScreenshot()
             screenshotOrientation = it.screenshotOrientation()

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -12,9 +12,7 @@ import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewCompat
 import androidx.webkit.WebViewFeature.*
-import dev.hotwire.core.config.Hotwire.pathConfiguration
 import dev.hotwire.core.lib.logging.logEvent
-import dev.hotwire.core.turbo.config.screenshotsEnabled
 import dev.hotwire.core.turbo.delegates.TurboFileChooserDelegate
 import dev.hotwire.core.turbo.errors.HttpError
 import dev.hotwire.core.turbo.errors.LoadError
@@ -63,12 +61,6 @@ class Session internal constructor(
      * Experimental: API may change, not ready for production use.
      */
     var offlineRequestHandler: TurboOfflineRequestHandler? = null
-
-    /**
-     * Returns whether transitional screenshots are enabled for this session. Default is `true`.
-     */
-    val screenshotsEnabled
-        get() = pathConfiguration.settings.screenshotsEnabled
 
     /**
      * Gets the nav destination that corresponds to the current WebView visit.

--- a/demo/src/main/assets/json/configuration.json
+++ b/demo/src/main/assets/json/configuration.json
@@ -1,7 +1,5 @@
 {
-  "settings": {
-    "screenshots_enabled": true
-  },
+  "settings": {},
   "rules": [
     {
       "patterns": [

--- a/docs/PATH-CONFIGURATION.md
+++ b/docs/PATH-CONFIGURATION.md
@@ -11,9 +11,7 @@ In its simplest form, your JSON configuration will look like:
 **`assets/json/configuration.json`:**
 ```json
 {
-  "settings": {
-    "screenshots_enabled": true
-  },
+  "settings": {},
   "rules": [
     {
       "patterns": [
@@ -53,11 +51,7 @@ Here's some tips for managing path configurations:
 - Try to keep your local and remote path configuration files in sync. When your app starts, Turbo will load your local configuration file, then make a request for your remote file which will override your local file. If the files are different and your server doesn't respond quickly, it's possible to get difficult to debug behaviour. If you're making other changes to your app that will require a new native deployment, that's a good time to update your local file to match the current state of your server.
 
 ## Settings
-The `settings` object is a place to configure app-level settings. This is useful when you have a remote configuration file, since you can add your own custom settings and use them as remote feature-flags. Available settings are:
-* `screenshots_enabled` — Whether or not transitional web screenshots should be used during navigation. This gives the appearance of a more smooth experience since the session WebView is swapped between web destination Fragments, but does require more performance overhead. 
-	* Optional.
-	* Possible values: `true`, `false`. Defaults to `true`.
-* Any custom app settings that you'd like to configure here
+The `settings` object is a place to configure app-level settings. This is useful when you have a remote configuration file, since you can add your own custom settings and use them as remote feature-flags. You can provide any custom app settings that you'd like to configure here.
 
 ## Rules
 The `"rules"` array defines a list of rules that are processed in order and cascade downward, similar to CSS. The top-most declaration should establish the default behavior for all url path patterns, while each subsequent rule can override for specific behavior.


### PR DESCRIPTION
This no longer needs to be an available app setting flag after the huge increase in device performance over the last 5 years. Closes https://github.com/hotwired/hotwire-native-android/issues/38.