### PR TITLE
Update HotwireNavigation.kt

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/config/HotwireNavigation.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/config/HotwireNavigation.kt
@@ -60,7 +60,7 @@ var Hotwire.defaultFragmentDestination: KClass<out Fragment>
 
 /**
  * Register fragment destinations that can be navigated to. Every possible
- * destination must be provided here.
+ * destination must be provided here, including one set via [defaultFragmentDestination].
  */
 fun Hotwire.registerFragmentDestinations(vararg destinations: KClass<out Fragment>) {
     HotwireNavigation.registeredFragmentDestinations = destinations.toList()


### PR DESCRIPTION
Note that when using `Hotwire.defaultFragmentDestination` it must also be added to `Hotwire.registerFragmentDestinations()`