### PR TITLE
Change Turbo Native to Hotwire Native in user agent.

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -73,7 +73,7 @@ class HotwireConfig internal constructor() {
      */
     fun userAgentSubstring(): String {
         val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
-        return "Turbo Native Android; bridge-components: [$components];"
+        return "Hotwire Native Android; bridge-components: [$components];"
     }
 
     /**

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -10,7 +10,7 @@ class UserAgentTest {
         Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
 
         val userAgentSubstring = Hotwire.config.userAgentSubstring()
-        assertEquals(userAgentSubstring, "Turbo Native Android; bridge-components: [one two];")
+        assertEquals(userAgentSubstring, "Hotwire Native Android; bridge-components: [one two];")
     }
 
     @Test
@@ -19,6 +19,6 @@ class UserAgentTest {
         Hotwire.config.userAgent = "Test; ${Hotwire.config.userAgentSubstring()}"
 
         val userAgent = Hotwire.config.userAgent
-        assertEquals(userAgent, "Test; Turbo Native Android; bridge-components: [one two];")
+        assertEquals(userAgent, "Test; Hotwire Native Android; bridge-components: [one two];")
     }
 }


### PR DESCRIPTION
Most everything that was named "Turbo" was renamed "Hotwire". I'm sure there's some reasoning here why this was not changed, but maybe it was missed. 

If someone needs it to still say "Turbo Native" for legacy reasons they can do this: 

```
Hotwire.config.userAgent = Hotwire.config.userAgentSubstring().replace("Hotwire Native", "Turbo Native")
```