### PR TITLE
Include "Turbo Native Android" in the user agent substring for compatibility

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -73,7 +73,7 @@ class HotwireConfig internal constructor() {
      */
     fun userAgentSubstring(): String {
         val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
-        return "Hotwire Native Android; bridge-components: [$components];"
+        return "Hotwire Native Android; Turbo Native Android; bridge-components: [$components];"
     }
 
     /**

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -10,7 +10,7 @@ class UserAgentTest {
         Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
 
         val userAgentSubstring = Hotwire.config.userAgentSubstring()
-        assertEquals(userAgentSubstring, "Hotwire Native Android; bridge-components: [one two];")
+        assertEquals(userAgentSubstring, "Hotwire Native Android; Turbo Native Android; bridge-components: [one two];")
     }
 
     @Test
@@ -19,6 +19,6 @@ class UserAgentTest {
         Hotwire.config.userAgent = "Test; ${Hotwire.config.userAgentSubstring()}"
 
         val userAgent = Hotwire.config.userAgent
-        assertEquals(userAgent, "Test; Hotwire Native Android; bridge-components: [one two];")
+        assertEquals(userAgent, "Test; Hotwire Native Android; Turbo Native Android; bridge-components: [one two];")
     }
 }


### PR DESCRIPTION
This allows servers to match against `Hotwire Native Android` or `Turbo Native Android` user agents. This matches the approach in the iOS library. 

This is a follow up to https://github.com/hotwired/hotwire-native-android/pull/66