### PR TITLE
Call sendDialogResult from onDialogDismiss (Fixes #63)

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt
@@ -86,10 +86,14 @@ class HotwireFragmentDelegate(private val navDestination: HotwireDestination) {
     }
 
     /**
-     * Provides a hook when the dialog has been dismissed.
+     * Provides a hook when the dialog has been dismissed. If there is a modal
+     * result, an event will be created in [SessionViewModel] that can be observed.
      */
     fun onDialogDismiss() {
         logEvent("fragment.onDialogDismiss", "location" to location)
+        if (!sessionViewModel.modalResultExists) {
+            sessionViewModel.sendDialogResult()
+        }
     }
 
     // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #63

`onDialogCancel` gets called when dialog is dismissed by pulling down. Everything works as expected. Screen does not freeze.

https://github.com/hotwired/hotwire-native-android/blob/218a7f799d4a4a5c721aa7f1aadff598970320d8/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt#L81-L86

`onDialogDismiss` gets called when close button is clicked. The screen freezes here.

https://github.com/hotwired/hotwire-native-android/blob/218a7f799d4a4a5c721aa7f1aadff598970320d8/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt#L91-L93