### PR TITLE
Provide the WebView system information in an easy to access way.

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -2,15 +2,24 @@ package dev.hotwire.core.config
 
 import android.content.Context
 import dev.hotwire.core.turbo.config.PathConfiguration
+import dev.hotwire.core.turbo.webview.WebViewInfo
 
 object Hotwire {
     val config: HotwireConfig = HotwireConfig()
+
+    /**
+     * Provides useful version and type information about the system WebView component installed
+     * on the device. This can be used in your app to require a minimum system WebView version on
+     * the device and point users to the Play Store to update the corresponding app (Google Chrome
+     * or Android System WebView).
+     */
+    fun webViewInfo(context: Context) = WebViewInfo(context.applicationContext)
 
     /**
      * Loads the [PathConfiguration] JSON file(s) from the provided location to
      * configure navigation rules.
      */
     fun loadPathConfiguration(context: Context, location: PathConfiguration.Location) {
-        config.pathConfiguration.load(context, location)
+        config.pathConfiguration.load(context.applicationContext, location)
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewInfo.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewInfo.kt
@@ -1,0 +1,67 @@
+package dev.hotwire.core.turbo.webview
+
+import android.content.Context
+import android.content.pm.PackageInfo
+import android.net.Uri
+import android.webkit.WebSettings
+import androidx.webkit.WebViewCompat
+
+private const val PACKAGE_SYSTEM_WEBVIEW = "com.google.android.webview"
+private const val PACKAGE_CHROME_WEBVIEW = "com.android.chrome"
+private const val PACKAGE_CHROME_PRE_RELEASE_WEBVIEW = "com.chrome"
+
+class WebViewInfo internal constructor(context: Context) {
+    enum class WebViewType {
+        ANDROID_SYSTEM,
+        CHROME,
+        UNKNOWN
+    }
+
+    /**
+     * The system WebView's package info (corresponds to Chrome or Android System WebView).
+     */
+    val packageInfo: PackageInfo? = WebViewCompat.getCurrentWebViewPackage(context)
+
+    /**
+     * The system WebView's major version (corresponds to Chrome or Android System WebView).
+     * Returns null if the major version cannot be determined.
+     */
+    val majorVersion: Int? = packageInfo?.versionName?.substringBefore(".")?.toIntOrNull()
+
+    /**
+     * The default User-Agent provided by the system WebView before a call is made
+     * to WebView.settings.setUserAgentString(String).
+     */
+    val defaultUserAgent: String = WebSettings.getDefaultUserAgent(context)
+
+    /**
+     * The system WebView's origin type. Different OS versions have the WebView component
+     * backed by either Google Chrome or the Android System WebView component. These are updatable
+     * through the Play Store.
+     */
+    val webViewType = when {
+        packageInfo?.packageName?.contains(PACKAGE_CHROME_WEBVIEW) == true -> WebViewType.CHROME
+        packageInfo?.packageName?.contains(PACKAGE_CHROME_PRE_RELEASE_WEBVIEW) == true -> WebViewType.CHROME
+        packageInfo?.packageName?.contains(PACKAGE_SYSTEM_WEBVIEW) == true -> WebViewType.ANDROID_SYSTEM
+        else -> WebViewType.UNKNOWN
+    }
+
+    /**
+     * The system WebView's origin type as a human readable string.
+     */
+    val webViewTypeName = when (webViewType) {
+        WebViewType.ANDROID_SYSTEM -> "Android System WebView"
+        WebViewType.CHROME -> "Google Chrome"
+        WebViewType.UNKNOWN -> "Unknown"
+    }
+
+    /**
+     * The Play Store app Uri for the system WebView type. This is useful to point users to the
+     * Play Store if their WebView version is outdated.
+     */
+    val playStoreWebViewAppUri = when (webViewType) {
+        WebViewType.ANDROID_SYSTEM -> Uri.parse("market://details?id=${PACKAGE_SYSTEM_WEBVIEW}")
+        WebViewType.CHROME -> Uri.parse("market://details?id=${PACKAGE_CHROME_WEBVIEW}")
+        else -> null
+    }
+}


### PR DESCRIPTION
Provides useful version and type information about the system `WebView` component installed on the device. This can be used in your app to require a minimum system WebView version on the device and point users to the Play Store to update the corresponding app (Google Chrome or Android System WebView).

Obtain the system `WebView` info through:
```kotlin
Hotwire.webViewInfo(context)
```