### PR TITLE
Allow apps to determine if a `Navigator` is ready for navigation

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
@@ -44,15 +44,16 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
 
     /**
      * Get the Activity's currently active [Navigator].
+     *
+     * Returns null if the navigator is not ready for navigation.
      */
     val currentNavigator: Navigator?
-        get() {
-            return if (currentNavigatorHost.isAdded && !currentNavigatorHost.isDetached) {
-                currentNavigatorHost.navigator
-            } else {
-                null
-            }
+        get() = if (currentNavigatorHost.isReady()) {
+            currentNavigatorHost.navigator
+        } else {
+            null
         }
+
 
     /**
      * Sets the currently active navigator in your Activity. If you use multiple
@@ -107,7 +108,7 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
     }
 
     private fun updateOnBackPressedCallback(navController: NavController) {
-        if (navController == currentNavigatorHost.navController)  {
+        if (navController == currentNavigatorHost.navController) {
             onBackPressedCallback.isEnabled = navController.previousBackStackEntry != null
         }
     }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
@@ -108,7 +108,7 @@ open class HotwireWebBottomSheetFragment : HotwireBottomSheetFragment(), Hotwire
 
     /**
      * Gets the HotwireView instance in the Fragment's view
-     * with resource ID R.id.turbo_view.
+     * with resource ID R.id.hotwire_view.
      */
     final override val hotwireView: HotwireView?
         get() = view?.findViewById(R.id.hotwire_view)

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
@@ -126,7 +126,7 @@ open class HotwireWebFragment : HotwireFragment(), HotwireWebFragmentCallback {
 
     /**
      * Gets the HotwireView instance in the Fragment's view
-     * with resource ID R.id.turbo_view.
+     * with resource ID R.id.hotwire_view.
      */
     final override val hotwireView: HotwireView?
         get() = view?.findViewById(R.id.hotwire_view)

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -64,6 +64,18 @@ class Navigator(
         }
     }
 
+    /**
+     * Returns whether the navigator and its host are ready for navigation. It is not
+     * ready for navigation if the host view is not attached or the start destination
+     * has not been created yet.
+     */
+    fun isReady(): Boolean {
+        return host.isReady()
+    }
+
+    /**
+     * Returns whether the current destination is the only backstack entry.
+     */
     fun isAtStartDestination(): Boolean {
         return navController.previousBackStackEntry == null
     }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -27,6 +27,10 @@ open class NavigatorHost : NavHostFragment() {
         activity.delegate.unregisterNavigatorHost(this)
     }
 
+    fun isReady(): Boolean {
+        return isAdded && !isDetached && childFragmentManager.primaryNavigationFragment != null
+    }
+
     internal fun initControllerGraph() {
         navController.apply {
             graph = NavigatorGraphBuilder(

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -27,6 +27,11 @@ open class NavigatorHost : NavHostFragment() {
         activity.delegate.unregisterNavigatorHost(this)
     }
 
+    /**
+     * Returns whether the navigation host is ready for navigation. It is not
+     * ready for navigation if the view is not attached or the start destination
+     * has not been created yet.
+     */
     fun isReady(): Boolean {
         return isAdded && !isDetached && childFragmentManager.primaryNavigationFragment != null
     }


### PR DESCRIPTION
Apps can call `navigator.isReady()` before performing any actions/routing. This can be useful from the main `Activity` while it's being created.