### PR TITLE
Fix crash/timing issues when the `Activity` is recreated

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivity.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivity.kt
@@ -2,6 +2,7 @@ package dev.hotwire.navigation.activities
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import dev.hotwire.navigation.navigator.Navigator
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 
 /**
@@ -11,7 +12,17 @@ abstract class HotwireActivity : AppCompatActivity() {
     lateinit var delegate: HotwireActivityDelegate
         private set
 
+    /**
+     * Provide a list of navigator configurations for the Activity. Configurations
+     * for all navigator instances available throughout the app should be provided here.
+     */
     abstract fun navigatorConfigurations(): List<NavigatorConfiguration>
+
+    /**
+     * Called when a navigator has been initialized and is ready for navigation. The
+     * root destination for the navigator has already been created.
+     */
+    open fun onNavigatorReady(navigator: Navigator) {}
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -19,6 +19,7 @@ import dev.hotwire.navigation.config.HotwireNavigation
 import dev.hotwire.navigation.fragments.HotwireFragmentDelegate
 import dev.hotwire.navigation.fragments.HotwireFragmentViewModel
 import dev.hotwire.navigation.navigator.Navigator
+import dev.hotwire.navigation.navigator.location
 import dev.hotwire.navigation.routing.Router
 
 /**
@@ -177,7 +178,4 @@ interface HotwireDestination : BridgeDestination {
     override fun bridgeWebViewIsReady(): Boolean {
         return navigator.session.isReady
     }
-
-    private val Bundle.location
-        get() = getString("location")
 }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireBottomSheetFragment.kt
@@ -21,12 +21,13 @@ import dev.hotwire.navigation.navigator.NavigatorHost
  */
 abstract class HotwireBottomSheetFragment : BottomSheetDialogFragment(),
     HotwireDestination, HotwireDialogDestination {
-    override lateinit var navigator: Navigator
     internal lateinit var delegate: HotwireFragmentDelegate
+
+    override val navigator: Navigator
+        get() = (parentFragment as NavigatorHost).navigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        navigator = (parentFragment as NavigatorHost).navigator
         delegate = HotwireFragmentDelegate(this)
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragment.kt
@@ -22,12 +22,13 @@ import dev.hotwire.navigation.session.SessionModalResult
  * For web fragments, refer to [HotwireWebFragment].
  */
 abstract class HotwireFragment : Fragment(), HotwireDestination {
-    override lateinit var navigator: Navigator
     internal lateinit var delegate: HotwireFragmentDelegate
+
+    override val navigator: Navigator
+        get() = (parentFragment as NavigatorHost).navigator
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        navigator = (parentFragment as NavigatorHost).navigator
         delegate = HotwireFragmentDelegate(this)
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt
@@ -2,6 +2,7 @@ package dev.hotwire.navigation.fragments
 
 import dev.hotwire.navigation.logging.logEvent
 import dev.hotwire.navigation.destinations.HotwireDestination
+import dev.hotwire.navigation.navigator.navigatorName
 import dev.hotwire.navigation.session.SessionModalResult
 import dev.hotwire.navigation.session.SessionViewModel
 import dev.hotwire.navigation.util.displayBackButton
@@ -15,10 +16,11 @@ import dev.hotwire.navigation.util.displayBackButtonAsCloseIcon
 class HotwireFragmentDelegate(private val navDestination: HotwireDestination) {
     private val fragment = navDestination.fragment
     private val location = navDestination.location
-    private val navigator = navDestination.navigator
+    private val navigatorName = requireNotNull(fragment.arguments?.navigatorName)
+    private val navigator get() = navDestination.navigator
 
     internal val sessionViewModel = SessionViewModel.get(
-        sessionName = navigator.configuration.name,
+        sessionName = navigatorName,
         activity = fragment.requireActivity()
     )
     internal val fragmentViewModel = HotwireFragmentViewModel.get(

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -45,7 +45,7 @@ internal class HotwireWebFragmentDelegate(
     private var screenshotOrientation = 0
     private var screenshotZoomed = false
     private var currentlyZoomed = false
-    private val navigator = navDestination.navigator
+    private val navigator get() = navDestination.navigator
     private val session get() = navigator.session
     private val turboView get() = callback.hotwireView
     private val viewTreeLifecycleOwner get() = turboView?.findViewTreeLifecycleOwner()

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -121,6 +121,7 @@ class Navigator(
             navOptions = navOptions(location, options.action),
             extras = extras,
             pathConfiguration = Hotwire.config.pathConfiguration,
+            navigatorName = configuration.name,
             controller = currentControllerForLocation(location)
         )
 
@@ -391,10 +392,7 @@ class Navigator(
     }
 
     private val NavBackStackEntry?.isModalContext: Boolean
-        get() {
-            val context = this?.arguments?.getSerializable("presentation-context")
-            return context as? PresentationContext == PresentationContext.MODAL
-        }
+        get() = this?.arguments?.presentationContext == PresentationContext.MODAL
 
     private fun logEvent(event: String, vararg params: Pair<String, Any>) {
         val attributes = params.toMutableList().apply {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorArguments.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorArguments.kt
@@ -1,0 +1,26 @@
+package dev.hotwire.navigation.navigator
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import dev.hotwire.core.turbo.nav.PresentationContext
+import dev.hotwire.navigation.logging.logError
+import kotlin.text.uppercase
+
+internal const val ARG_LOCATION = "location"
+internal const val ARG_NAVIGATOR_NAME = "navigator-name"
+internal const val ARG_PRESENTATION_CONTEXT = "presentation-context"
+
+internal val Bundle.location
+    get() = getString(ARG_LOCATION)
+
+internal val Bundle.navigatorName
+    get() = getString(ARG_NAVIGATOR_NAME)
+
+internal val Bundle.presentationContext
+    @SuppressLint("DefaultLocale") get() = try {
+        val value = getString(ARG_PRESENTATION_CONTEXT) ?: "default"
+        PresentationContext.valueOf(value.uppercase())
+    } catch (e: IllegalArgumentException) {
+        logError("unknownPresentationContext", e)
+        PresentationContext.DEFAULT
+    }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorGraphBuilder.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorGraphBuilder.kt
@@ -22,6 +22,7 @@ import kotlin.reflect.KClass
 import kotlin.reflect.full.isSubclassOf
 
 internal class NavigatorGraphBuilder(
+    private val navigatorName: String,
     private val startLocation: String,
     private val navController: NavController,
     private val pathConfiguration: PathConfiguration
@@ -69,8 +70,12 @@ internal class NavigatorGraphBuilder(
                 }
             }
 
-            argument("location") {
+            argument(ARG_LOCATION) {
                 defaultValue = startLocation
+            }
+
+            argument(ARG_NAVIGATOR_NAME) {
+                defaultValue = navigatorName
             }
 
             // Use a random value to represent a unique instance of the graph, so the

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -1,13 +1,17 @@
 package dev.hotwire.navigation.navigator
 
 import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentOnAttachListener
 import androidx.navigation.fragment.NavHostFragment
 import androidx.navigation.fragment.findNavController
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.config.HotwireNavigation
 
-open class NavigatorHost : NavHostFragment() {
+open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
     internal lateinit var activity: HotwireActivity
     lateinit var navigator: Navigator
         private set
@@ -16,15 +20,25 @@ open class NavigatorHost : NavHostFragment() {
         super.onCreate(savedInstanceState)
 
         activity = requireActivity() as HotwireActivity
-        activity.delegate.registerNavigatorHost(this)
         navigator = Navigator(this, configuration)
+        childFragmentManager.addFragmentOnAttachListener(this)
 
         initControllerGraph()
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        activity.delegate.registerNavigatorHost(this)
+    }
+
+    override fun onAttachFragment(fragmentManager: FragmentManager, fragment: Fragment) {
+        activity.delegate.onNavigatorHostReady(this)
+        childFragmentManager.removeFragmentOnAttachListener(this)
+    }
+
     override fun onDestroy() {
-        super.onDestroy()
         activity.delegate.unregisterNavigatorHost(this)
+        super.onDestroy()
     }
 
     /**
@@ -39,6 +53,7 @@ open class NavigatorHost : NavHostFragment() {
     internal fun initControllerGraph() {
         navController.apply {
             graph = NavigatorGraphBuilder(
+                navigatorName = configuration.name,
                 startLocation = configuration.startLocation,
                 pathConfiguration = Hotwire.config.pathConfiguration,
                 navController = findNavController()

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -33,6 +33,7 @@ internal class NavigatorRule(
     navOptions: NavOptions,
     extras: FragmentNavigator.Extras?,
     pathConfiguration: PathConfiguration,
+    navigatorName: String,
     val controller: NavController
 ) {
     val defaultUri = HotwireDestinationDeepLink.from(HotwireNavigation.defaultFragmentDestination).uri.toUri()
@@ -45,6 +46,7 @@ internal class NavigatorRule(
     val isAtStartDestination = controller.previousBackStackEntry == null
 
     // New destination
+    val newNavigatorName = navigatorName
     val newLocation = location
     val newProperties = pathConfiguration.properties(newLocation)
     val newPresentationContext = newProperties.context
@@ -156,8 +158,9 @@ internal class NavigatorRule(
     private fun Bundle?.withNavArguments(): Bundle {
         val bundle = this ?: bundleOf()
         return bundle.apply {
-            putString("location", newLocation)
-            putSerializable("presentation-context", newPresentationContext)
+            putString(ARG_LOCATION, newLocation)
+            putString(ARG_NAVIGATOR_NAME, newNavigatorName)
+            putString(ARG_PRESENTATION_CONTEXT, newPresentationContext.name)
         }
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/util/NavigationExtensions.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/util/NavigationExtensions.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.navigation.NavBackStackEntry
 import dev.hotwire.navigation.R
+import dev.hotwire.navigation.navigator.location
 
 fun Toolbar.displayBackButton() {
     navigationIcon = ContextCompat.getDrawable(context, R.drawable.ic_back)
@@ -19,7 +20,7 @@ fun Toolbar.displayBackButtonAsCloseIcon() {
 }
 
 internal val NavBackStackEntry?.location: String?
-    get() = this?.arguments?.getString("location")
+    get() = this?.arguments?.location
 
 internal fun Context.colorFromThemeAttr(
     @AttrRes attrColor: Int,

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
@@ -52,6 +52,7 @@ class NavigatorRuleTest {
     private val webModalUri = Uri.parse("hotwire://fragment/web/modal")
     private val webHomeUri = Uri.parse("hotwire://fragment/web/home")
 
+    private val navigatorName = "test"
     private val extras = null
     private val navOptions = navOptions {
         anim {
@@ -387,12 +388,19 @@ class NavigatorRuleTest {
         bundle: Bundle? = null
     ): NavigatorRule {
         return NavigatorRule(
-            location, visitOptions, bundle, navOptions, extras, pathConfiguration, controller
+            location = location,
+            visitOptions = visitOptions,
+            bundle = bundle,
+            navOptions = navOptions,
+            extras = extras,
+            pathConfiguration = pathConfiguration,
+            navigatorName = navigatorName,
+            controller = controller
         )
     }
 
     private fun locationArgs(location: String): Bundle {
-        return bundleOf("location" to location)
+        return bundleOf(ARG_LOCATION to location)
     }
 
     private fun buildControllerWithGraph(): TestNavHostController {
@@ -421,7 +429,8 @@ class NavigatorRuleTest {
                         navigator = provider.getNavigator<NavGraphNavigator>("test"),
                         id = webHomeDestinationId
                     ).apply {
-                        argument("location") { defaultValue = homeUrl }
+                        argument(ARG_LOCATION) { defaultValue = homeUrl }
+                        argument(ARG_NAVIGATOR_NAME) { defaultValue = navigatorName }
                         deepLink(webHomeUri.toString())
                     }
                 )


### PR DESCRIPTION
Follow up to: https://github.com/hotwired/hotwire-native-android/pull/72

Additionally, this allows an app to listen for when navigators are ready for navigation after the Activity is (re)created.
```kotlin
class MainActivity : HotwireActivity() {
    override  fun onNavigatorReady(navigator: Navigator) {
        // custom code for navigation
    }
}
```