### PR TITLE
Fix bottom sheet dialog fragment navigation issues

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireBottomSheetFragment.kt
@@ -33,6 +33,7 @@ abstract class HotwireBottomSheetFragment : BottomSheetDialogFragment(),
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        navigator.currentDialogDestination = this
         delegate.onViewCreated()
 
         if (shouldObserveTitleChanges()) {
@@ -41,6 +42,11 @@ abstract class HotwireBottomSheetFragment : BottomSheetDialogFragment(),
                 fragmentViewModel.setTitle(it)
             }
         }
+    }
+
+    override fun onDestroyView() {
+        navigator.currentDialogDestination = null
+        super.onDestroyView()
     }
 
     /**


### PR DESCRIPTION
This fixes regressions when refactoring the `Navigator` to use a single instance across a navigation host (instead of one per destination). The topmost `DialogFragment` is not available from the `NavigatorHost.childFragmentManager`, since it is added directly to the `Activity`'s window instead.

Fixes https://github.com/hotwired/hotwire-native-android/issues/63 and closes https://github.com/hotwired/hotwire-native-android/pull/69.