### PR TITLE
Breaking API change: applications can set a User-Agent prefix

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -65,22 +65,27 @@ class HotwireConfig internal constructor() {
     }
 
     /**
-     * Provides a standard substring to be included in your WebView's user agent
-     * to identify itself as a Hotwire Native app.
-     *
-     * Important: Ensure that you've registered your bridge components before
-     * calling this so the bridge component names are included in your user agent.
+     * Set a custom user agent application prefix for every WebView instance. The
+     * library will automatically append a substring to your prefix which includes:
+     * - "Hotwire Native Android; Turbo Native Android;"
+     * - "bridge-components: [your bridge components];"
+     * - The WebView's default Chromium user agent string
      */
-    fun userAgentSubstring(): String {
-        val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
-        return "Hotwire Native Android; Turbo Native Android; bridge-components: [$components];"
-    }
+    var applicationUserAgentPrefix: String? = null
 
     /**
-     * Set a custom user agent for every WebView instance.
-     *
-     * Important: Include `Hotwire.userAgentSubstring()` as part of your
-     * custom user agent for compatibility with your server.
+     * Gets the full user agent that is used for every WebView instance. This includes:
+     * - Your (optional) custom `applicationUserAgentPrefix`
+     * - "Hotwire Native Android; Turbo Native Android;"
+     * - "bridge-components: [your bridge components];"
+     * - The WebView's default Chromium user agent string
      */
-    var userAgent: String = userAgentSubstring()
+    fun userAgent(context: Context): String {
+        val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
+
+        return applicationUserAgentPrefix?.let { "$it " }.orEmpty() +
+                "Hotwire Native Android; Turbo Native Android; " +
+                "bridge-components: [$components]; " +
+                Hotwire.webViewInfo(context).defaultUserAgent
+    }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -83,9 +83,11 @@ class HotwireConfig internal constructor() {
     fun userAgent(context: Context): String {
         val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
 
-        return applicationUserAgentPrefix?.let { "$it " }.orEmpty() +
-                "Hotwire Native Android; Turbo Native Android; " +
-                "bridge-components: [$components]; " +
-                Hotwire.webViewInfo(context).defaultUserAgent
+        return listOf(
+            applicationUserAgentPrefix,
+            "Hotwire Native Android; Turbo Native Android;",
+            "bridge-components: [$components];",
+            Hotwire.webViewInfo(context).defaultUserAgent
+        ).filterNotNull().joinToString(" ")
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.res.Configuration
 import android.os.Build
 import android.util.AttributeSet
-import android.view.View
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.FrameLayout.LayoutParams.MATCH_PARENT
@@ -36,10 +35,10 @@ open class HotwireWebView @JvmOverloads constructor(
         internal set
 
     init {
-        id = View.generateViewId()
+        id = generateViewId()
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
-        settings.userAgentString = "${Hotwire.config.userAgent} ${settings.userAgentString}"
+        settings.userAgentString = Hotwire.config.userAgent(context)
         settings.setSupportMultipleWindows(true)
         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
         initDayNightTheming()

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -1,24 +1,58 @@
 package dev.hotwire.core.bridge
 
+import android.content.Context
+import android.os.Build
+import androidx.test.core.app.ApplicationProvider
 import dev.hotwire.core.config.Hotwire
+import dev.hotwire.core.turbo.BaseUnitTest
 import org.junit.Assert.assertEquals
+import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
 
-class UserAgentTest {
-    @Test
-    fun userAgentSubstring() {
-        Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class UserAgentTest : BaseUnitTest() {
+    private lateinit var context: Context
 
-        val userAgentSubstring = Hotwire.config.userAgentSubstring()
-        assertEquals(userAgentSubstring, "Hotwire Native Android; Turbo Native Android; bridge-components: [one two];")
+    @Before
+    override fun setup() {
+        super.setup()
+        context = ApplicationProvider.getApplicationContext()
+        Hotwire.config.applicationUserAgentPrefix = null
     }
 
     @Test
-    fun userAgent() {
+    fun `user agent with no prefix`() {
         Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
-        Hotwire.config.userAgent = "Test; ${Hotwire.config.userAgentSubstring()}"
 
-        val userAgent = Hotwire.config.userAgent
-        assertEquals(userAgent, "Test; Hotwire Native Android; Turbo Native Android; bridge-components: [one two];")
+        val userAgent = Hotwire.config.userAgent(context)
+        val expectedUserAgent =
+                "Hotwire Native Android; Turbo Native Android; " +
+                "bridge-components: [one two]; " +
+                TEST_USER_AGENT
+
+        assertEquals(expectedUserAgent, userAgent)
+    }
+
+    @Test
+    fun `user agent with prefix`() {
+        Hotwire.config.applicationUserAgentPrefix = "My Application Prefix;"
+        Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
+
+        val userAgent = Hotwire.config.userAgent(context)
+        val expectedUserAgent =
+                "My Application Prefix; " +
+                "Hotwire Native Android; Turbo Native Android; " +
+                "bridge-components: [one two]; " +
+                TEST_USER_AGENT
+
+        assertEquals(expectedUserAgent, userAgent)
+    }
+
+    companion object {
+        private const val TEST_USER_AGENT = "user"
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
@@ -69,6 +69,6 @@ class DemoApplication : Application() {
         Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG
         Hotwire.config.webViewDebuggingEnabled = BuildConfig.DEBUG
         Hotwire.config.jsonConverter = KotlinXJsonConverter()
-        Hotwire.config.userAgent = "Hotwire Demo; ${Hotwire.config.userAgentSubstring()}"
+        Hotwire.config.applicationUserAgentPrefix = "Hotwire Demo;"
     }
 }


### PR DESCRIPTION
This resolves issues like these:
- https://github.com/hotwired/hotwire-native-android/issues/64
- https://github.com/hotwired/hotwire-native-android/issues/68

Applications can now set a custom `applicationUserAgentPrefix` for their application via:
```kotlin
Hotwire.config.applicationUserAgentPrefix = "My Application Prefix"
```

Whenever a `WebView` instance is created, the library will now automatically include:
- Your (optional) custom `applicationUserAgentPrefix`
- "Hotwire Native Android; Turbo Native Android;"
- "bridge-components: [your bridge components];"
- The WebView's default Chromium user agent string

Since this a breaking API change, we'll include this is in an upcoming `v1.1` release.