### PR TITLE
Disable link prefetching to match the new behavior on iOS

### DIFF
--- a/core/src/main/assets/js/turbo.js
+++ b/core/src/main/assets/js/turbo.js
@@ -167,6 +167,8 @@
     }
 
     linkPrefetchingIsEnabledForLocation(location) {
+      // Disable link prefetching since it can be activated by link taps. We
+      // don't want to prefetch links that may correspond to native screens.
       return false
     }
 

--- a/core/src/main/assets/js/turbo.js
+++ b/core/src/main/assets/js/turbo.js
@@ -166,6 +166,10 @@
       TurboSession.pageInvalidated()
     }
 
+    linkPrefetchingIsEnabledForLocation(location) {
+      return false
+    }
+
     // Private
 
     afterNextRepaint(callback) {


### PR DESCRIPTION
This updates the link prefetching behavior to match iOS in https://github.com/hotwired/hotwire-native-ios/pull/62. It works with the new adapter function in core `turbo.js` added here: https://github.com/hotwired/turbo/pull/1354