### PR TITLE
Support non string path config property values

### DIFF
--- a/core/src/main/assets/json/test-configuration.json
+++ b/core/src/main/assets/json/test-configuration.json
@@ -94,6 +94,19 @@
         "uri": "hotwire://fragment/web/modal",
         "presentation": "replace_root"
       }
+    },
+    {
+      "patterns": [
+        "/custom/tabs"
+      ],
+      "properties": {
+        "tabs": [
+          {
+            "label": "Tab 1",
+            "path": "/tab1"
+          }
+        ]
+      }
     }
   ]
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -104,13 +104,13 @@ class PathConfiguration {
     }
 }
 
-typealias PathConfigurationProperties = HashMap<String, String>
+typealias PathConfigurationProperties = HashMap<String, Any>
 typealias PathConfigurationSettings = HashMap<String, String>
 
 val PathConfigurationProperties.presentation: Presentation
     @SuppressLint("DefaultLocale") get() = try {
         val value = get("presentation") ?: "default"
-        Presentation.valueOf(value.uppercase())
+        Presentation.valueOf(value.toString().uppercase())
     } catch (e: IllegalArgumentException) {
         Presentation.DEFAULT
     }
@@ -118,7 +118,7 @@ val PathConfigurationProperties.presentation: Presentation
 val PathConfigurationProperties.queryStringPresentation: QueryStringPresentation
     @SuppressLint("DefaultLocale") get() = try {
         val value = get("query_string_presentation") ?: "default"
-        QueryStringPresentation.valueOf(value.uppercase())
+        QueryStringPresentation.valueOf(value.toString().uppercase())
     } catch (e: IllegalArgumentException) {
         QueryStringPresentation.DEFAULT
     }
@@ -126,19 +126,19 @@ val PathConfigurationProperties.queryStringPresentation: QueryStringPresentation
 val PathConfigurationProperties.context: PresentationContext
     @SuppressLint("DefaultLocale") get() = try {
         val value = get("context") ?: "default"
-        PresentationContext.valueOf(value.uppercase())
+        PresentationContext.valueOf(value.toString().uppercase())
     } catch (e: IllegalArgumentException) {
         PresentationContext.DEFAULT
     }
 
-val PathConfigurationProperties.uri: Uri?
-    get() = get("uri")?.toUri()
+val PathConfigurationProperties.uri: Uri
+    get() = get("uri").let { it.toString().toUri() }
 
-val PathConfigurationProperties.fallbackUri: Uri?
-    get() = get("fallback_uri")?.toUri()
+val PathConfigurationProperties.fallbackUri: Uri
+    get() = get("fallback_uri").let { it.toString().toUri() }
 
 val PathConfigurationProperties.title: String?
-    get() = get("title")
+    get() = get("title") as String?
 
 val PathConfigurationProperties.pullToRefreshEnabled: Boolean
-    get() = get("pull_to_refresh_enabled")?.toBoolean() ?: false
+    get() = get("pull_to_refresh_enabled").let { it as Boolean }

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
@@ -51,7 +51,7 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
         assertThat(json).isNotNull()
 
         val config = load(json)
-        assertThat(config?.rules?.size).isEqualTo(10)
+        assertThat(config?.rules?.size).isEqualTo(11)
     }
 
     @Test

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -3,11 +3,15 @@ package dev.hotwire.core.turbo.config
 import android.content.Context
 import android.os.Build
 import androidx.test.core.app.ApplicationProvider
+import com.google.gson.annotations.SerializedName
+import com.google.gson.reflect.TypeToken
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
 import dev.hotwire.core.turbo.BaseRepositoryTest
 import dev.hotwire.core.turbo.config.PathConfiguration.Location
 import dev.hotwire.core.turbo.nav.PresentationContext
+import dev.hotwire.core.turbo.util.toJson
+import dev.hotwire.core.turbo.util.toObject
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
@@ -38,7 +42,7 @@ class PathConfigurationTest : BaseRepositoryTest() {
 
     @Test
     fun assetConfigurationIsLoaded() {
-        assertThat(pathConfiguration.rules.size).isEqualTo(10)
+        assertThat(pathConfiguration.rules.size).isEqualTo(11)
     }
 
     @Test
@@ -84,4 +88,20 @@ class PathConfigurationTest : BaseRepositoryTest() {
         assertThat(pathConfiguration.properties("$url/home").pullToRefreshEnabled).isTrue
         assertThat(pathConfiguration.properties("$url/new").pullToRefreshEnabled).isFalse
     }
+
+    @Test
+    fun customProperties() {
+        assertThat((pathConfiguration.properties("$url/custom/tabs").getTabs()?.size)).isEqualTo(1)
+        assertThat((pathConfiguration.properties("$url/custom/tabs").getTabs()?.first()?.label)).isEqualTo("Tab 1")
+    }
+
+    //    Extension function to show support for serialising custom properties
+    private fun PathConfigurationProperties.getTabs(): List<Tab>? {
+        return get("tabs")?.toJson()?.toObject(object : TypeToken<List<Tab>>() {})
+    }
+
+    internal data class Tab(
+        @SerializedName("label") val label: String,
+        @SerializedName("path") val path: String
+    )
 }


### PR DESCRIPTION
Previously the JSON parser would only accept strings as possible values for `properties`. Because of this it was impossible to create a custom data structure inside the path-configuration file. 

The iOS configuration parser does support non string values, intent here is to match parity with the other platform.

In doing so it allows for custom extension functions to be added to `PathConfigurationProperties` which allows developers to serialize their own data structures.