### PR TITLE
Move Cookies persisting off the main thread

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/observers/HotwireActivityObserver.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/observers/HotwireActivityObserver.kt
@@ -3,6 +3,9 @@ package dev.hotwire.navigation.observers
 import android.webkit.CookieManager
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import dev.hotwire.navigation.util.dispatcherProvider
+import kotlinx.coroutines.launch
 
 internal class HotwireActivityObserver : DefaultLifecycleObserver {
     /**
@@ -13,7 +16,9 @@ internal class HotwireActivityObserver : DefaultLifecycleObserver {
      */
     override fun onStop(owner: LifecycleOwner) {
         super.onStop(owner)
-        persistWebViewCookies()
+        owner.lifecycleScope.launch(dispatcherProvider.io) {
+            persistWebViewCookies()
+        }
     }
 
     private fun persistWebViewCookies() {


### PR DESCRIPTION
CookieManager.flush function documentation states:

> This call will block the caller until it is done and may perform I/O.

This may result in ANRs for applications using the library. 
This PR adds a fix by moving the call off the main thread.