### PR TITLE
Fix modal navigation

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -138,7 +138,7 @@ internal class NavigatorRule(
             location = newLocation,
             options = newVisitOptions,
             bundle = newBundle,
-            shouldNavigate = newProperties.presentation != Presentation.NONE
+            shouldNavigate = newProperties.presentation != Presentation.NONE && newProperties.presentation != Presentation.POP
         )
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -121,10 +121,10 @@ internal class NavigatorRule(
                 newPresentation != Presentation.REPLACE_ROOT
 
         return when {
+            presentationNone -> NavigatorMode.NONE
             dismissModalContext -> NavigatorMode.DISMISS_MODAL
             navigateToModalContext -> NavigatorMode.TO_MODAL
             presentationRefresh -> NavigatorMode.REFRESH
-            presentationNone -> NavigatorMode.NONE
             else -> NavigatorMode.IN_CONTEXT
         }
     }


### PR DESCRIPTION
This PR attempts to solve the issue #84.     

Problems solved:
- [x] Modal closes after redirecting to /resume_historical_location
- [x] Jump to the first fragment, when a modal was closed on the second fragment via /recede_historical_location

One left inconsistency between Android and iOS is that: 
- After the modal is popped, through /recede_historical_location, Android requests the location of the previous fragment. iOS doesn't do a request.     
Seems to me, that happens because the navigator always request the location of the newly attached fragment in: [HotwireWebFragmentDelegate.kt#328](https://github.com/hotwired/hotwire-native-android/blob/main/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt#L326)   
Not sure how to proceed here.    

Another thing is, that the app previously freezed when the modal was popped through /recede_historical_location on the first fragment (as mentioned in the issue). I've fixed that by setting `shouldNavigate` to false, if we are popping a fragment.    
But i guess it could be worth to investigate more, why the app freezed in the first place.   