### PR TITLE
return null with pathConfiguredFailedToParse exception

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationLoader.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationLoader.kt
@@ -63,10 +63,12 @@ internal class PathConfigurationLoader(val context: Context) : CoroutineScope {
         repository.cacheConfigurationForUrl(context, url, pathConfiguration)
     }
 
-    private fun load(json: String) = try {
-        json.toObject(object : TypeToken<PathConfiguration>() {})
-    } catch(e: Exception) {
-        logError("pathConfiguredFailedToParse", e)
-        null
+    fun load(json: String): PathConfiguration? {
+     return try {
+            json.toObject(object : TypeToken<PathConfiguration>() {})
+        } catch (e: Exception) {
+            logError("pathConfiguredFailedToParse", e)
+            null
+        }
     }
 }

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
@@ -54,6 +54,20 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
     }
 
     @Test
+    fun getMalformedRemoteConfiguration() {
+        enqueueResponse("malformed-body.json")
+        val loader = PathConfigurationLoader(context)
+
+        runBlocking {
+            launch(Dispatchers.Main) {
+                val json = repository.getRemoteConfiguration(baseUrl())
+                val pathConfiguration = json?.let { loader.load(it) }
+                assertThat(pathConfiguration).isNull()
+            }
+        }
+    }
+
+    @Test
     fun getCachedConfiguration() {
         val url = "https://turbo.hotwired.dev/demo/configurations/android-v1.json"
         val config = requireNotNull(load(json()))

--- a/core/src/test/resources/http-responses/malformed-body.json
+++ b/core/src/test/resources/http-responses/malformed-body.json
@@ -1,0 +1,2 @@
+malformed-body
+


### PR DESCRIPTION
When I was exploring the codebase, I noticed this [issue](https://github.com/hotwired/hotwire-native-android/issues/87) and changed the return value to null in the case of an exception on parsing malformed json. 

