### PR TITLE
Separate `Hotwire.config.userAgent` from `Hotwire.config.userAgentWithWebViewDefault`

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/HotwireConfig.kt
@@ -74,20 +74,30 @@ class HotwireConfig internal constructor() {
     var applicationUserAgentPrefix: String? = null
 
     /**
+     * Gets the user agent that the library builds to identify the app
+     * and its registered bridge components. This includes:
+     * - Your (optional) custom `applicationUserAgentPrefix`
+     * - "Hotwire Native Android; Turbo Native Android;"
+     * - "bridge-components: [your bridge components];"
+     */
+    val userAgent: String get() {
+        val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
+
+        return listOf(
+            applicationUserAgentPrefix,
+            "Hotwire Native Android; Turbo Native Android;",
+            "bridge-components: [$components];"
+        ).filterNotNull().joinToString(" ")
+    }
+
+    /**
      * Gets the full user agent that is used for every WebView instance. This includes:
      * - Your (optional) custom `applicationUserAgentPrefix`
      * - "Hotwire Native Android; Turbo Native Android;"
      * - "bridge-components: [your bridge components];"
      * - The WebView's default Chromium user agent string
      */
-    fun userAgent(context: Context): String {
-        val components = registeredBridgeComponentFactories.joinToString(" ") { it.name }
-
-        return listOf(
-            applicationUserAgentPrefix,
-            "Hotwire Native Android; Turbo Native Android;",
-            "bridge-components: [$components];",
-            Hotwire.webViewInfo(context).defaultUserAgent
-        ).filterNotNull().joinToString(" ")
+    fun userAgentWithWebViewDefault(context: Context): String {
+        return "$userAgent ${Hotwire.webViewInfo(context).defaultUserAgent}"
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -111,7 +111,7 @@ class Session(
 
         offlineHttpRepository.preCache(
             requestHandler, OfflinePreCacheRequest(
-                url = location, userAgent = webView.settings.userAgentString
+                url = location, userAgent = Hotwire.config.userAgentWithWebViewDefault(context)
             )
         )
     }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
@@ -38,7 +38,7 @@ open class HotwireWebView @JvmOverloads constructor(
         id = generateViewId()
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true
-        settings.userAgentString = Hotwire.config.userAgent(context)
+        settings.userAgentString = Hotwire.config.userAgentWithWebViewDefault(context)
         settings.setSupportMultipleWindows(true)
         layoutParams = FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT)
         initDayNightTheming()

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/UserAgentTest.kt
@@ -28,11 +28,10 @@ class UserAgentTest : BaseUnitTest() {
     fun `user agent with no prefix`() {
         Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
 
-        val userAgent = Hotwire.config.userAgent(context)
+        val userAgent = Hotwire.config.userAgent
         val expectedUserAgent =
                 "Hotwire Native Android; Turbo Native Android; " +
-                "bridge-components: [one two]; " +
-                TEST_USER_AGENT
+                "bridge-components: [one two];"
 
         assertEquals(expectedUserAgent, userAgent)
     }
@@ -42,12 +41,26 @@ class UserAgentTest : BaseUnitTest() {
         Hotwire.config.applicationUserAgentPrefix = "My Application Prefix;"
         Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
 
-        val userAgent = Hotwire.config.userAgent(context)
+        val userAgent = Hotwire.config.userAgent
         val expectedUserAgent =
                 "My Application Prefix; " +
                 "Hotwire Native Android; Turbo Native Android; " +
-                "bridge-components: [one two]; " +
-                TEST_USER_AGENT
+                "bridge-components: [one two];"
+
+        assertEquals(expectedUserAgent, userAgent)
+    }
+
+    @Test
+    fun `user agent with prefix and webview default`() {
+        Hotwire.config.applicationUserAgentPrefix = "My Application Prefix;"
+        Hotwire.config.registeredBridgeComponentFactories = TestData.componentFactories
+
+        val userAgent = Hotwire.config.userAgentWithWebViewDefault(context)
+        val expectedUserAgent =
+            "My Application Prefix; " +
+                    "Hotwire Native Android; Turbo Native Android; " +
+                    "bridge-components: [one two]; " +
+                    TEST_USER_AGENT
 
         assertEquals(expectedUserAgent, userAgent)
     }


### PR DESCRIPTION
This helps align the API available in the iOS library here: https://github.com/hotwired/hotwire-native-ios/pull/75

There are now two readable strings that applications can use:
- `Hotwire.config.userAgent`
- `Hotwire.config.userAgentWithWebViewDefault(context)`

Since the `WebView`'s default user agent string API is different (and accessible) on Android, it is also provided for an application to read/use.