### PR TITLE
Prevent pull to refresh on specific elements

### DIFF
--- a/core/src/main/assets/js/turbo.js
+++ b/core/src/main/assets/js/turbo.js
@@ -206,8 +206,10 @@
     while (element) {
       const canScroll = element.scrollHeight > element.clientHeight
       const overflowY = window.getComputedStyle(element).overflowY
+      const isScrollable = canScroll && (overflowY === "scroll" || overflowY === "auto")
+      const preventPullToRefresh = !!element.closest("[data-native-prevent-pull-to-refresh]")
 
-      if (canScroll && (overflowY === "scroll" || overflowY === "auto")) {
+      if (isScrollable || preventPullToRefresh) {
         TurboSession.elementTouchStarted(true)
         break
       }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -568,8 +568,8 @@ class Session(
      * You should never call this directly as it could lead to unintended behavior.
      */
     @JavascriptInterface
-    fun elementTouchStarted(scrollable: Boolean) {
-        webView.elementTouchIsScrollable = scrollable
+    fun elementTouchStarted(preventsPullsToRefresh: Boolean) {
+        webView.elementTouchPreventsPullsToRefresh = preventsPullsToRefresh
     }
 
     /**
@@ -580,7 +580,7 @@ class Session(
      */
     @JavascriptInterface
     fun elementTouchEnded() {
-        webView.elementTouchIsScrollable = false
+        webView.elementTouchPreventsPullsToRefresh = false
     }
 
     // Private

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
@@ -31,7 +31,7 @@ open class HotwireWebView @JvmOverloads constructor(
 ) : WebView(context, attrs) {
     private val gson = GsonBuilder().disableHtmlEscaping().create()
 
-    var elementTouchIsScrollable = false
+    var elementTouchPreventsPullsToRefresh = false
         internal set
 
     init {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/views/HotwireSwipeRefreshLayout.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/views/HotwireSwipeRefreshLayout.kt
@@ -17,7 +17,7 @@ internal class HotwireSwipeRefreshLayout @JvmOverloads constructor(context: Cont
         val webView = children.firstOrNull() as? HotwireWebView
 
         return if (webView != null) {
-            webView.scrollY > 0 || webView.elementTouchIsScrollable
+            webView.scrollY > 0 || webView.elementTouchPreventsPullsToRefresh
         } else {
             false
         }


### PR DESCRIPTION
This PR introduces a way to prevent the pull to refresh behavior on specific elements.   
~~When an element (or its ancestor) has `data-hotwire-native-prevent-pull-to-refresh` attribute, pull to refresh is disabled.~~
When an element (or its ancestor) has `data-native-prevent-pull-to-refresh` attribute, pull to refresh is disabled.

All the examples shown in #97 could be solved by adding the data attribute to the respective elements.

This introduces a difference from Hotwire Native iOS, since iOS doesn't need this attribute, which isn't ideal.  
But I currently don't see a better solution. Happy to discuss this further and maybe find a better solution.   


