### PR TITLE
Edge full edge-to-edge Activity view without system bar insets

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/util/CoreExtensions.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/util/CoreExtensions.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.core.turbo.util
 
 import android.content.Context
+import android.content.res.Configuration
 import android.os.Handler
 import android.webkit.WebResourceRequest
 import com.google.gson.Gson
@@ -9,6 +10,11 @@ import com.google.gson.reflect.TypeToken
 import dev.hotwire.core.turbo.visit.VisitAction
 import dev.hotwire.core.turbo.visit.VisitActionAdapter
 import java.io.File
+
+val Context.isNightModeEnabled: Boolean get() {
+    val currentNightMode = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
+    return currentNightMode == Configuration.UI_MODE_NIGHT_YES
+}
 
 internal fun WebResourceRequest.isHttpGetRequest(): Boolean {
     return method.equals("GET", ignoreCase = true) &&

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
@@ -14,6 +14,7 @@ import androidx.webkit.WebViewFeature
 import com.google.gson.GsonBuilder
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.util.contentFromAsset
+import dev.hotwire.core.turbo.util.isNightModeEnabled
 import dev.hotwire.core.turbo.util.runOnUiThread
 import dev.hotwire.core.turbo.util.toJson
 import dev.hotwire.core.turbo.visit.VisitOptions
@@ -107,16 +108,11 @@ open class HotwireWebView @JvmOverloads constructor(
             }
 
             if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
-                when (isNightModeEnabled(context)) {
+                when (context.isNightModeEnabled) {
                     true -> WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_ON)
                     else -> WebSettingsCompat.setForceDark(settings, WebSettingsCompat.FORCE_DARK_AUTO)
                 }
             }
         }
-    }
-
-    private fun isNightModeEnabled(context: Context): Boolean {
-        val currentNightMode = context.resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK
-        return currentNightMode == Configuration.UI_MODE_NIGHT_YES
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/features/imageviewer/ImageViewerFragment.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/features/imageviewer/ImageViewerFragment.kt
@@ -6,8 +6,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.core.view.WindowCompat
-import androidx.core.view.WindowInsetsCompat
 import coil.load
+import dev.hotwire.core.turbo.util.isNightModeEnabled
 import dev.hotwire.demo.R
 import dev.hotwire.navigation.destinations.HotwireDestinationDeepLink
 import dev.hotwire.navigation.fragments.HotwireFragment
@@ -39,19 +39,17 @@ class ImageViewerFragment : HotwireFragment() {
 
     override fun onStart() {
         super.onStart()
-        val windowInsetsController = WindowCompat.getInsetsController(
-            requireActivity().window,
-            requireActivity().window.decorView
-        )
-        windowInsetsController.hide(WindowInsetsCompat.Type.systemBars())
+
+        val window = requireActivity().window
+        WindowCompat.getInsetsController(window, window.decorView)
+            .isAppearanceLightStatusBars = false
     }
 
     override fun onStop() {
         super.onStop()
-        val windowInsetsController = WindowCompat.getInsetsController(
-            requireActivity().window,
-            requireActivity().window.decorView
-        )
-        windowInsetsController.show(WindowInsetsCompat.Type.systemBars())
+
+        val window = requireActivity().window
+        WindowCompat.getInsetsController(window, window.decorView)
+            .isAppearanceLightStatusBars = !requireContext().isNightModeEnabled
     }
 }

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -1,17 +1,20 @@
 package dev.hotwire.demo.main
 
 import android.os.Bundle
+import android.view.View
 import androidx.activity.enableEdgeToEdge
 import dev.hotwire.demo.R
 import dev.hotwire.demo.Urls
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
+import dev.hotwire.navigation.util.applyDefaultImeWindowInsets
 
 class MainActivity : HotwireActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        findViewById<View>(R.id.root_view).applyDefaultImeWindowInsets()
     }
 
     override fun navigatorConfigurations() = listOf(

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -1,20 +1,17 @@
 package dev.hotwire.demo.main
 
 import android.os.Bundle
-import android.view.View
 import androidx.activity.enableEdgeToEdge
 import dev.hotwire.demo.R
 import dev.hotwire.demo.Urls
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
-import dev.hotwire.navigation.util.applyDefaultWindowInsets
 
 class MainActivity : HotwireActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        findViewById<View>(R.id.root_view).applyDefaultWindowInsets()
     }
 
     override fun navigatorConfigurations() = listOf(

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -3,7 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/root_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".main.MainActivity">

--- a/demo/src/main/res/layout/activity_main.xml
+++ b/demo/src/main/res/layout/activity_main.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/root_view"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".main.MainActivity">

--- a/demo/src/main/res/layout/fragment_web_home.xml
+++ b/demo/src/main/res/layout/fragment_web_home.xml
@@ -8,14 +8,15 @@
     <com.google.android.material.appbar.AppBarLayout
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="56dp"
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <FrameLayout
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="56dp">
 
             <com.google.android.material.appbar.MaterialToolbar
                 android:id="@+id/toolbar"

--- a/demo/src/main/res/values/motion.xml
+++ b/demo/src/main/res/values/motion.xml
@@ -3,11 +3,6 @@
 
     <!--Motion-->
 
-    <style name="Animation.MyTheme.BottomSheet.Modal" parent="Animation.AppCompat.Dialog">
-        <item name="android:windowEnterAnimation">@anim/dialog_sheet_slide_in</item>
-        <item name="android:windowExitAnimation">@anim/dialog_sheet_slide_out</item>
-    </style>
-
     <style name="Animation.MyTheme.AlertDialog" parent="Animation.AppCompat.Dialog">
         <item name="android:windowEnterAnimation">@anim/dialog_sheet_slide_in</item>
         <item name="android:windowExitAnimation">@anim/dialog_sheet_slide_out</item>

--- a/demo/src/main/res/values/styles.xml
+++ b/demo/src/main/res/values/styles.xml
@@ -9,8 +9,6 @@
         <item name="android:windowAnimationStyle">@style/Animation.MyTheme.BottomSheet.Modal</item>
         <item name="android:statusBarColor">@color/transparent</item>
         <item name="bottomSheetStyle">@style/Widget.MyTheme.BottomSheet.Modal</item>
-        <item name="android:navigationBarColor">?colorSurface</item>
-        <item name="android:navigationBarDividerColor" tools:ignore="NewApi">@color/transparent</item>
     </style>
 
     <style name="Widget.MyTheme.BottomSheet.Modal" parent="Widget.MaterialComponents.BottomSheet.Modal">
@@ -35,6 +33,10 @@
         <item name="titleTextColor">?colorOnSurface</item>
         <item name="subtitleTextColor">?colorSecondary</item>
         <item name="elevation">@dimen/toolbar_elevation</item>
+    </style>
+
+    <style name="Widget.MyTheme.AppBarLayout" parent="Widget.MaterialComponents.AppBarLayout.Surface">
+        <item name="android:background">?colorSurface</item>
     </style>
 
     <style name="Widget.MyTheme.Toolbar.Navigation.Tinted" parent="Widget.AppCompat.Toolbar.Button.Navigation">

--- a/demo/src/main/res/values/styles.xml
+++ b/demo/src/main/res/values/styles.xml
@@ -6,7 +6,6 @@
     <style name="ThemeOverlay.MyTheme.BottomSheetDialog" parent="ThemeOverlay.MaterialComponents.BottomSheetDialog">
         <item name="android:windowIsFloating">false</item>
         <item name="android:windowBackground">@color/transparent</item>
-        <item name="android:windowAnimationStyle">@style/Animation.MyTheme.BottomSheet.Modal</item>
         <item name="android:statusBarColor">@color/transparent</item>
         <item name="bottomSheetStyle">@style/Widget.MyTheme.BottomSheet.Modal</item>
     </style>

--- a/demo/src/main/res/values/themes.xml
+++ b/demo/src/main/res/values/themes.xml
@@ -56,6 +56,7 @@
         <item name="materialAlertDialogTheme">@style/ThemeOverlay.MyTheme.AlertDialog</item>
         <item name="bottomSheetDialogTheme">@style/ThemeOverlay.MyTheme.BottomSheetDialog</item>
         <item name="toolbarStyle">@style/Widget.MyTheme.Toolbar</item>
+        <item name="appBarLayoutStyle">@style/Widget.MyTheme.AppBarLayout</item>
         <item name="materialButtonStyle">@style/Widget.MyTheme.Button</item>
         <item name="buttonOutlineStyle">@style/Widget.MyTheme.OutlinedButton</item>
         <item name="buttonTextStyle">@style/Widget.MyTheme.TextButton</item>
@@ -67,9 +68,9 @@
         <item name="alphaEmphasisMedium">@dimen/alpha_emphasis_medium</item>
         <item name="alphaEmphasisDisabled">@dimen/alpha_emphasis_disabled</item>
 
-        <item name="android:statusBarColor">?colorSurface</item>
+        <item name="android:statusBarColor">@color/transparent</item>
         <item name="android:windowLightStatusBar">true</item>
-        <item name="android:navigationBarColor">?colorSurface</item>
+        <item name="android:navigationBarColor">@color/transparent</item>
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:navigationBarDividerColor">@color/transparent</item>
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/util/NavigationExtensions.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/util/NavigationExtensions.kt
@@ -2,9 +2,12 @@ package dev.hotwire.navigation.util
 
 import android.content.Context
 import android.util.TypedValue
+import android.view.View
 import androidx.annotation.AttrRes
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.navigation.NavBackStackEntry
 import dev.hotwire.navigation.R
 import dev.hotwire.navigation.navigator.location
@@ -15,6 +18,15 @@ fun Toolbar.displayBackButton() {
 
 fun Toolbar.displayBackButtonAsCloseIcon() {
     navigationIcon = ContextCompat.getDrawable(context, R.drawable.ic_close)
+}
+
+fun View.applyDefaultImeWindowInsets() {
+    ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
+        insets.getInsets(WindowInsetsCompat.Type.ime()).apply {
+            v.setPadding(left, top, right, bottom)
+        }
+        insets
+    }
 }
 
 internal val NavBackStackEntry?.location: String?

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/util/NavigationExtensions.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/util/NavigationExtensions.kt
@@ -2,12 +2,9 @@ package dev.hotwire.navigation.util
 
 import android.content.Context
 import android.util.TypedValue
-import android.view.View
 import androidx.annotation.AttrRes
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.navigation.NavBackStackEntry
 import dev.hotwire.navigation.R
 import dev.hotwire.navigation.navigator.location
@@ -34,12 +31,4 @@ internal fun Context.colorFromThemeAttr(
     attr.recycle()
 
     return attrValue
-}
-
-fun View.applyDefaultWindowInsets() {
-    ViewCompat.setOnApplyWindowInsetsListener(this) { v, insets ->
-        val insetTypes = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime()
-        insets.getInsets(insetTypes).apply { v.setPadding(left, top, right, bottom) }
-        insets
-    }
 }

--- a/navigation-fragments/src/main/res/layout/hotwire_fragment_web.xml
+++ b/navigation-fragments/src/main/res/layout/hotwire_fragment_web.xml
@@ -9,6 +9,7 @@
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:fitsSystemWindows="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">


### PR DESCRIPTION
This builds on #95, but enables a more modern look with scrolling content underneath the navigation gesture bar:

![Screenshot_20250220-105753](https://github.com/user-attachments/assets/c2655ad5-a3b1-4fa5-83e5-f3b3802b6e4d)
