### PR TITLE
Add `animated` Path Configuration property

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -157,3 +157,6 @@ val PathConfigurationProperties.title: String?
 
 val PathConfigurationProperties.pullToRefreshEnabled: Boolean
     get() = get("pull_to_refresh_enabled")?.toBoolean() ?: false
+
+val PathConfigurationProperties.animated: Boolean
+    get() = get("animated")?.toBoolean() ?: true

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -10,6 +10,7 @@ import androidx.navigation.navOptions
 import dev.hotwire.core.bridge.BridgeDestination
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.core.turbo.config.PathConfigurationProperties
+import dev.hotwire.core.turbo.config.animated
 import dev.hotwire.core.turbo.config.context
 import dev.hotwire.core.turbo.config.presentation
 import dev.hotwire.core.turbo.nav.Presentation
@@ -139,7 +140,7 @@ interface HotwireDestination : BridgeDestination {
     ): NavOptions {
         val modal = newPathProperties.context == PresentationContext.MODAL
         val clearAll = newPathProperties.presentation == Presentation.CLEAR_ALL
-        val animate = action != VisitAction.REPLACE &&
+        val animate = newPathProperties.animated && action != VisitAction.REPLACE &&
                 newPathProperties.presentation != Presentation.REPLACE &&
                 newPathProperties.presentation != Presentation.REPLACE_ROOT
 


### PR DESCRIPTION
This PR would add the ability to add an `animated` property to the path configuration, which would allow to disable the default animation when navigating to a path. 
It's an effort to add more feature parity with iOS.   