### PR TITLE
Improved `default` context visit behavior when dismissing the `modal` context

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -137,21 +137,26 @@ interface HotwireDestination : BridgeDestination {
         newPathProperties: PathConfigurationProperties,
         action: VisitAction
     ): NavOptions {
-        val navigatingToModal = newPathProperties.context == PresentationContext.MODAL
+        val navigatingToModalContext = pathProperties.context == PresentationContext.DEFAULT &&
+                newPathProperties.context == PresentationContext.MODAL
 
-        val dismissingModal = pathProperties.context == PresentationContext.MODAL &&
+        val navigatingWithinModalContext = pathProperties.context == PresentationContext.MODAL &&
+                newPathProperties.context == PresentationContext.MODAL
+
+        val dismissingModalContext = pathProperties.context == PresentationContext.MODAL &&
                 newPathProperties.context == PresentationContext.DEFAULT
 
-        val animate = action != VisitAction.REPLACE &&
+        val animate = (navigatingToModalContext || dismissingModalContext) ||
+                (action != VisitAction.REPLACE &&
                 newPathProperties.presentation != Presentation.REPLACE &&
-                newPathProperties.presentation != Presentation.REPLACE_ROOT
+                newPathProperties.presentation != Presentation.REPLACE_ROOT)
 
         val clearAll = newPathProperties.presentation == Presentation.CLEAR_ALL
 
-        return if (navigatingToModal || dismissingModal) {
+        return if (navigatingToModalContext || navigatingWithinModalContext || dismissingModalContext) {
             navOptions {
                 anim {
-                    enter = R.anim.enter_slide_in_bottom
+                    enter = if (animate) R.anim.enter_slide_in_bottom else 0
                     exit = R.anim.exit_slide_out_bottom
                     popEnter = R.anim.enter_slide_in_bottom
                     popExit = R.anim.exit_slide_out_bottom

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -137,16 +137,22 @@ interface HotwireDestination : BridgeDestination {
         newPathProperties: PathConfigurationProperties,
         action: VisitAction
     ): NavOptions {
-        val modal = newPathProperties.context == PresentationContext.MODAL
-        val clearAll = newPathProperties.presentation == Presentation.CLEAR_ALL
+        val navigatingToModal = pathProperties.context == PresentationContext.DEFAULT &&
+                newPathProperties.context == PresentationContext.MODAL
+
+        val dismissingModal = pathProperties.context == PresentationContext.MODAL &&
+                newPathProperties.context == PresentationContext.DEFAULT
+
         val animate = action != VisitAction.REPLACE &&
                 newPathProperties.presentation != Presentation.REPLACE &&
                 newPathProperties.presentation != Presentation.REPLACE_ROOT
 
-        return if (modal) {
+        val clearAll = newPathProperties.presentation == Presentation.CLEAR_ALL
+
+        return if (navigatingToModal || dismissingModal) {
             navOptions {
                 anim {
-                    enter = if (animate) R.anim.enter_slide_in_bottom else 0
+                    enter = R.anim.enter_slide_in_bottom
                     exit = R.anim.exit_slide_out_bottom
                     popEnter = R.anim.enter_slide_in_bottom
                     popExit = R.anim.exit_slide_out_bottom

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -137,8 +137,7 @@ interface HotwireDestination : BridgeDestination {
         newPathProperties: PathConfigurationProperties,
         action: VisitAction
     ): NavOptions {
-        val navigatingToModal = pathProperties.context == PresentationContext.DEFAULT &&
-                newPathProperties.context == PresentationContext.MODAL
+        val navigatingToModal = newPathProperties.context == PresentationContext.MODAL
 
         val dismissingModal = pathProperties.context == PresentationContext.MODAL &&
                 newPathProperties.context == PresentationContext.DEFAULT

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -82,12 +82,12 @@ internal class NavigatorRule(
         val locationIsCurrent = locationsAreSame(newLocation, currentLocation)
         val locationIsPrevious = locationsAreSame(newLocation, previousLocation)
         val replace = newVisitOptions.action == VisitAction.REPLACE
-        val dismissToDefaultContext = currentPresentationContext == PresentationContext.MODAL &&
+        val dismissModalContext = currentPresentationContext == PresentationContext.MODAL &&
                 newPresentationContext == PresentationContext.DEFAULT
 
         return when {
             locationIsCurrent && isAtStartDestination -> Presentation.REPLACE_ROOT
-            locationIsPrevious || dismissToDefaultContext -> Presentation.POP
+            locationIsPrevious || dismissModalContext -> Presentation.POP
             locationIsCurrent || replace -> Presentation.REPLACE
             else -> Presentation.PUSH
         }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -82,10 +82,12 @@ internal class NavigatorRule(
         val locationIsCurrent = locationsAreSame(newLocation, currentLocation)
         val locationIsPrevious = locationsAreSame(newLocation, previousLocation)
         val replace = newVisitOptions.action == VisitAction.REPLACE
+        val dismissToDefaultContext = currentPresentationContext == PresentationContext.MODAL &&
+                newPresentationContext == PresentationContext.DEFAULT
 
         return when {
             locationIsCurrent && isAtStartDestination -> Presentation.REPLACE_ROOT
-            locationIsPrevious -> Presentation.POP
+            locationIsPrevious || dismissToDefaultContext -> Presentation.POP
             locationIsCurrent || replace -> Presentation.REPLACE
             else -> Presentation.PUSH
         }
@@ -134,9 +136,16 @@ internal class NavigatorRule(
             return null
         }
 
+        // When dismissing a modal, override the visit action. A visit proposal with an
+        // original "replace" action is respected by first dismissing the modal. But we
+        // don't want to also "replace" the underlying default context screen (unless
+        // the urls are the same).
+        val locationIsPrevious = locationsAreSame(newLocation, previousLocation)
+        val action = if (locationIsPrevious) VisitAction.REPLACE else VisitAction.ADVANCE
+
         return SessionModalResult(
             location = newLocation,
-            options = newVisitOptions,
+            options = newVisitOptions.copy(action = action),
             bundle = newBundle,
             shouldNavigate = newProperties.presentation != Presentation.NONE
         )

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -136,10 +136,10 @@ internal class NavigatorRule(
             return null
         }
 
-        // When dismissing a modal, override the visit action. A visit proposal with an
-        // original "replace" action is respected by first dismissing the modal. But we
-        // don't want to also "replace" the underlying default context screen (unless
-        // the urls are the same).
+        // When dismissing a modal to navigate in the "default" context, override the visit
+        // action. A visit proposal with an original "replace" action is respected by first
+        // dismissing the modal. But we don't want to also "replace" the underlying "default"
+        // context screen (unless the urls are the same).
         val locationIsPrevious = locationsAreSame(newLocation, previousLocation)
         val action = if (locationIsPrevious) VisitAction.REPLACE else VisitAction.ADVANCE
 

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
@@ -15,6 +15,7 @@ import androidx.test.core.app.ApplicationProvider
 import dev.hotwire.core.turbo.config.PathConfiguration
 import dev.hotwire.core.turbo.config.PathConfiguration.Location
 import dev.hotwire.core.turbo.nav.*
+import dev.hotwire.core.turbo.visit.VisitAction
 import dev.hotwire.core.turbo.visit.VisitOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -35,6 +36,7 @@ class NavigatorRuleTest {
     private val homeUrl = "https://hotwired.dev/home"
     private val newHomeUrl = "https://hotwired.dev/new-home"
     private val featureUrl = "https://hotwired.dev/feature"
+    private val featureTwoUrl = "https://hotwired.dev/feature-two"
     private val newUrl = "https://hotwired.dev/feature/new"
     private val editUrl = "https://hotwired.dev/feature/edit"
     private val recedeUrl = "https://hotwired.dev/custom/recede"
@@ -196,6 +198,56 @@ class NavigatorRuleTest {
         assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.REPLACE)
         assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.DISMISS_MODAL)
         assertThat(rule.newModalResult?.location).isEqualTo(featureUrl)
+        assertThat(rule.newDestinationUri).isEqualTo(webUri)
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `navigating back to feature from modal context with replace action maintains replace`() {
+        controller.navigate(webDestinationId, locationArgs(featureUrl))
+        controller.navigate(webModalDestinationId, locationArgs(newUrl))
+        val rule = getNavigatorRule(featureUrl, VisitOptions(action = VisitAction.REPLACE))
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(featureUrl)
+        assertThat(rule.currentLocation).isEqualTo(newUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(PresentationContext.MODAL)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(featureUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(Presentation.POP)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.REPLACE)
+        assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.DISMISS_MODAL)
+        assertThat(rule.newModalResult?.location).isEqualTo(featureUrl)
+        assertThat(rule.newModalResult?.options?.action).isEqualTo(VisitAction.REPLACE)
+        assertThat(rule.newDestinationUri).isEqualTo(webUri)
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `navigating to new feature from modal context with replace action changes to advance`() {
+        controller.navigate(webDestinationId, locationArgs(featureUrl))
+        controller.navigate(webModalDestinationId, locationArgs(newUrl))
+        val rule = getNavigatorRule(featureTwoUrl, VisitOptions(action = VisitAction.REPLACE))
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(featureUrl)
+        assertThat(rule.currentLocation).isEqualTo(newUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(PresentationContext.MODAL)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(featureTwoUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(Presentation.POP)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.REPLACE)
+        assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.DISMISS_MODAL)
+        assertThat(rule.newModalResult?.location).isEqualTo(featureTwoUrl)
+        assertThat(rule.newModalResult?.options?.action).isEqualTo(VisitAction.ADVANCE)
         assertThat(rule.newDestinationUri).isEqualTo(webUri)
         assertThat(rule.newDestination).isNotNull()
         assertThat(rule.newNavOptions).isEqualTo(navOptions)


### PR DESCRIPTION
This aligns the modal -> navigation context switching behavior to the same behavior as the iOS changes here: https://github.com/hotwired/hotwire-native-ios/pull/98

> This PR fixes an issue when you're in the modal context and a visit is proposed to the default context. If that visit proposal contains a replace action, we don't want to both dismiss the modal screen and then replace the underlying default context screen. That can lead to replacing the default context screen that should be preserved, such as the root destination.
>
> The only scenario where we'll both dismiss the modal screen and replace is if the underlying default context is the same URL as the proposed URL.

In practice, this doesn't actually change the visible behavior in the Android library. We were using a `Presentation.REPLACE` to dismiss modals and push a new item on the stack before, which resulted in the desired behavior outlined above. 

But now, we'll use `Presentation.POP` + `Presentation.ADVANCE` to more appropriately represent what happens when a `modal` context is dismissed and a new `default` context destination is pushed onto the stack. Tests have been added to confirm the new behavior.

-------------------------

This also tweaks the default animation logic, so we have proper modal dismiss animations, even when it's immediately followed by a `replace` visit on the previous screen.