### PR TITLE
Rename the new path config `ClientConfig `class to `LoaderOptions` to match the iOS API

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -20,14 +20,14 @@ object Hotwire {
      * configure navigation rules.
      * @param context The application or activity context.
      * @param location Specifies local and/or remote location to retrieve path configuration files.
-     * @param clientConfig Optional HTTP client configuration options to use when fetching remote
-     *  path configuration files from your server.
+     * @param options Optional loader options to use when fetching remote path configuration files
+     *  from your server.
      */
     fun loadPathConfiguration(
         context: Context,
         location: PathConfiguration.Location,
-        clientConfig: PathConfiguration.ClientConfig = PathConfiguration.ClientConfig()
+        options: PathConfiguration.LoaderOptions = PathConfiguration.LoaderOptions()
     ) {
-        config.pathConfiguration.load(context.applicationContext, location, clientConfig)
+        config.pathConfiguration.load(context.applicationContext, location, options)
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -55,14 +55,13 @@ class PathConfiguration {
     )
 
     /**
-     * HTTP client configuration options when fetching remote path configuration
-     * files from your server.
+     * Loader options when fetching remote path configuration files from your server.
      */
-    data class ClientConfig(
+    data class LoaderOptions(
         /**
-         * Custom headers to send with each remote path configuration file request.
+         * Custom HTTP headers to send with each remote path configuration file request.
          */
-        val headers: Map<String, String> = emptyMap()
+        val httpHeaders: Map<String, String> = emptyMap()
     )
 
     /**
@@ -72,13 +71,13 @@ class PathConfiguration {
     fun load(
         context: Context,
         location: Location,
-        clientConfig: ClientConfig
+        options: LoaderOptions
     ) {
         if (loader == null) {
             loader = PathConfigurationLoader(context.applicationContext)
         }
 
-        loader?.load(location, clientConfig) {
+        loader?.load(location, options) {
             cachedProperties.clear()
             rules = it.rules
             settings = it.settings

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationLoader.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationLoader.kt
@@ -19,7 +19,7 @@ internal class PathConfigurationLoader(val context: Context) : CoroutineScope {
 
     fun load(
         location: PathConfiguration.Location,
-        clientConfig: PathConfiguration.ClientConfig,
+        options: PathConfiguration.LoaderOptions,
         onCompletion: (PathConfiguration) -> Unit
     ) {
         location.assetFilePath?.let {
@@ -27,20 +27,20 @@ internal class PathConfigurationLoader(val context: Context) : CoroutineScope {
         }
 
         location.remoteFileUrl?.let {
-            downloadRemoteConfiguration(it, clientConfig, onCompletion)
+            downloadRemoteConfiguration(it, options, onCompletion)
         }
     }
 
     private fun downloadRemoteConfiguration(
         url: String,
-        clientConfig: PathConfiguration.ClientConfig,
+        options: PathConfiguration.LoaderOptions,
         onCompletion: (PathConfiguration) -> Unit
     ) {
         // Always load the previously cached version first, if available
         loadCachedConfigurationForUrl(url, onCompletion)
 
         launch {
-            repository.getRemoteConfiguration(url, clientConfig)?.let { json ->
+            repository.getRemoteConfiguration(url, options)?.let { json ->
                 load(json)?.let {
                     logEvent("remotePathConfigurationLoaded", url)
                     onCompletion(it)

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepository.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepository.kt
@@ -15,11 +15,11 @@ internal class PathConfigurationRepository {
 
     suspend fun getRemoteConfiguration(
         url: String,
-        clientConfig: PathConfiguration.ClientConfig
+        options: PathConfiguration.LoaderOptions
     ): String? {
         val requestBuilder = Request.Builder().url(url)
 
-        clientConfig.headers.forEach { (key, value) ->
+        options.httpHeaders.forEach { (key, value) ->
             requestBuilder.header(key, value)
         }
 

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
@@ -5,7 +5,7 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.google.gson.reflect.TypeToken
 import dev.hotwire.core.turbo.BaseRepositoryTest
-import dev.hotwire.core.turbo.config.PathConfiguration.*
+import dev.hotwire.core.turbo.config.PathConfiguration.LoaderOptions
 import dev.hotwire.core.turbo.util.toObject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -35,7 +35,7 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
 
         runBlocking {
             launch(Dispatchers.Main) {
-                val json = repository.getRemoteConfiguration(baseUrl(), ClientConfig())
+                val json = repository.getRemoteConfiguration(baseUrl(), LoaderOptions())
                 assertThat(json).isNotNull()
 
                 val config = load(json)
@@ -70,8 +70,8 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
     fun `getRemoteConfiguration should include custom headers`() {
         enqueueResponse("test-configuration.json")
 
-        val clientConfig = ClientConfig(
-            headers = mapOf(
+        val options = LoaderOptions(
+            httpHeaders = mapOf(
                 "Accept" to "application/json",
                 "Custom-Header" to "test-value"
             )
@@ -79,7 +79,7 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
 
         runBlocking {
             launch(Dispatchers.Main) {
-                repository.getRemoteConfiguration(baseUrl(), clientConfig)
+                repository.getRemoteConfiguration(baseUrl(), options)
 
                 val request = server.takeRequest()
                 assertThat(request.headers["Custom-Header"]).isEqualTo("test-value")

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -5,7 +5,7 @@ import android.os.Build
 import androidx.test.core.app.ApplicationProvider
 import com.nhaarman.mockito_kotlin.*
 import dev.hotwire.core.turbo.BaseRepositoryTest
-import dev.hotwire.core.turbo.config.PathConfiguration.ClientConfig
+import dev.hotwire.core.turbo.config.PathConfiguration.LoaderOptions
 import dev.hotwire.core.turbo.config.PathConfiguration.Location
 import dev.hotwire.core.turbo.nav.PresentationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -25,8 +25,8 @@ class PathConfigurationTest : BaseRepositoryTest() {
     private lateinit var pathConfiguration: PathConfiguration
     private val mockRepository = mock<PathConfigurationRepository>()
     private val url = "https://turbo.hotwired.dev"
-    private val clientConfig = ClientConfig(
-        headers = mapOf(
+    private val options = LoaderOptions(
+        httpHeaders = mapOf(
             "Accept" to "application/json",
             "Custom-Header" to "test-value"
         )
@@ -41,7 +41,7 @@ class PathConfigurationTest : BaseRepositoryTest() {
             load(
                 context = context,
                 location = Location(assetFilePath = "json/test-configuration.json"),
-                clientConfig = clientConfig
+                options = options
             )
         }
     }
@@ -70,11 +70,11 @@ class PathConfigurationTest : BaseRepositoryTest() {
         runBlocking {
             val remoteUrl = "$url/demo/configurations/android-v1.json"
             val location = Location(remoteFileUrl = remoteUrl)
-            val clientConfig = PathConfiguration.ClientConfig()
+            val options = LoaderOptions()
 
-            pathConfiguration.load(context, location, clientConfig)
+            pathConfiguration.load(context, location, options)
             verify(mockRepository).getCachedConfigurationForUrl(context, remoteUrl)
-            verify(mockRepository).getRemoteConfiguration(remoteUrl, clientConfig)
+            verify(mockRepository).getRemoteConfiguration(remoteUrl, options)
         }
     }
 
@@ -87,13 +87,13 @@ class PathConfigurationTest : BaseRepositoryTest() {
         runBlocking {
             val remoteUrl = "$url/demo/configurations/android-v1.json"
             val location = Location(remoteFileUrl = remoteUrl)
-            val clientConfig = PathConfiguration.ClientConfig()
+            val options = LoaderOptions()
             val json = """{ "settings": {}, "rules": [] }"""
 
-            whenever(mockRepository.getRemoteConfiguration(remoteUrl, clientConfig))
+            whenever(mockRepository.getRemoteConfiguration(remoteUrl, options))
                 .thenReturn(json)
 
-            pathConfiguration.load(context, location, clientConfig)
+            pathConfiguration.load(context, location, options)
             verify(mockRepository).cacheConfigurationForUrl(eq(context), eq(remoteUrl), any())
         }
     }
@@ -107,13 +107,13 @@ class PathConfigurationTest : BaseRepositoryTest() {
         runBlocking {
             val remoteUrl = "$url/demo/configurations/android-v1.json"
             val location = Location(remoteFileUrl = remoteUrl)
-            val clientConfig = PathConfiguration.ClientConfig()
+            val options = LoaderOptions()
             val json = "malformed-json"
 
-            whenever(mockRepository.getRemoteConfiguration(remoteUrl, clientConfig))
+            whenever(mockRepository.getRemoteConfiguration(remoteUrl, options))
                 .thenReturn(json)
 
-            pathConfiguration.load(context, location, clientConfig)
+            pathConfiguration.load(context, location, options)
             verify(mockRepository, never()).cacheConfigurationForUrl(any(), any(), any())
         }
     }

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
@@ -14,7 +14,9 @@ import androidx.navigation.ui.R
 import androidx.test.core.app.ApplicationProvider
 import dev.hotwire.core.turbo.config.PathConfiguration
 import dev.hotwire.core.turbo.config.PathConfiguration.Location
-import dev.hotwire.core.turbo.nav.*
+import dev.hotwire.core.turbo.nav.Presentation
+import dev.hotwire.core.turbo.nav.PresentationContext
+import dev.hotwire.core.turbo.nav.QueryStringPresentation
 import dev.hotwire.core.turbo.visit.VisitOptions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -72,7 +74,7 @@ class NavigatorRuleTest {
             load(
                 context = context,
                 location = Location(assetFilePath = "json/test-configuration.json"),
-                clientConfig = PathConfiguration.ClientConfig()
+                options = PathConfiguration.LoaderOptions()
             )
         }
     }


### PR DESCRIPTION
This tweaks the public API naming from: https://github.com/hotwired/hotwire-native-android/pull/102

This renames the `PathConfiguration.ClientConfig` class to `PathConfiguration.LoaderOptions`, which aligns with the corresponding iOS library API.

So, instead of:
```kotlin
Hotwire.loadPathConfiguration(
    context = this,
    location = PathConfiguration.Location(
        assetFilePath = "json/configuration.json"
    ),
    clientConfig = PathConfiguration.ClientConfig(
        headers = mapOf(
            "Accept" to "*/*, text/html, application/json",
            "X-Custom-Header" to "custom-value"
        )
    )
)
```

It now looks like:
```kotlin
Hotwire.loadPathConfiguration(
    context = this,
    location = PathConfiguration.Location(
        assetFilePath = "json/configuration.json"
    ),
    options = PathConfiguration.LoaderOptions(
        httpHeaders = mapOf(
            "Accept" to "*/*, text/html, application/json",
            "X-Custom-Header" to "custom-value"
        )
    )
)
```

This `ClientConfig` API wasn't released in a public version yet, so there are no backwards compatibility concerns.