### PR TITLE
Fix when navigating from a modal sheet dialog -> modal sheet dialog

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireBottomSheetFragment.kt
@@ -98,6 +98,7 @@ abstract class HotwireBottomSheetFragment : BottomSheetDialogFragment(),
 
     override fun closeDialog() {
         requireDialog().cancel()
+        navigator.currentDialogDestination = null
     }
 
     override fun onBeforeNavigation() {}


### PR DESCRIPTION
This fixes https://github.com/hotwired/hotwire-native-android/issues/92

Previously, navigating from a modal sheet dialog -> modal sheet dialog with an `ADVANCE` action would result in a blank webview sheet. Due to the significant complexity in allowing multiple dialog sheets on the stack together, we'll now only permit one dialog on top of the stack at a time. So, if there's already an active dialog sheet, it will be dismissed before navigating to the next dialog sheet.

This behavior is the same as using a `REPLACE` action between dialog sheets. Although, this isn't the ideal outcome, it's the only realistic solution for the time being until we can make a deeper investment in how modal dialog navigation is handled. Dialog fragments have an unusual lifecycle, so we can't depend on the natural `Fragment` lifecycle event flow like full screen fragment destinations.