### PR TITLE
Add `animated` Path Configuration property

### DIFF
--- a/core/src/main/assets/json/test-configuration.json
+++ b/core/src/main/assets/json/test-configuration.json
@@ -94,6 +94,14 @@
         "uri": "hotwire://fragment/web/modal",
         "presentation": "replace_root"
       }
+    },
+    {
+      "patterns": [
+        "/not-animated"
+      ],
+      "properties": {
+        "animated": false
+      }
     }
   ]
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -156,3 +156,6 @@ val PathConfigurationProperties.title: String?
 
 val PathConfigurationProperties.pullToRefreshEnabled: Boolean
     get() = get("pull_to_refresh_enabled")?.toBoolean() ?: false
+
+val PathConfigurationProperties.animated: Boolean
+    get() = get("animated")?.toBoolean() ?: true

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
@@ -50,7 +50,7 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
         assertThat(json).isNotNull()
 
         val config = load(json)
-        assertThat(config?.rules?.size).isEqualTo(10)
+        assertThat(config?.rules?.size).isEqualTo(11)
     }
 
     @Test

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -48,7 +48,7 @@ class PathConfigurationTest : BaseRepositoryTest() {
 
     @Test
     fun assetConfigurationIsLoaded() {
-        assertThat(pathConfiguration.rules.size).isEqualTo(10)
+        assertThat(pathConfiguration.rules.size).isEqualTo(11)
     }
 
     @Test
@@ -128,6 +128,13 @@ class PathConfigurationTest : BaseRepositoryTest() {
     @Test
     fun title() {
         assertThat(pathConfiguration.properties("$url/image.jpg").title).isEqualTo("Image Viewer")
+    }
+
+    @Test
+    fun animated() {
+        assertThat(pathConfiguration.properties("$url/home").animated).isTrue()
+        assertThat(pathConfiguration.properties("$url/new").animated).isTrue()
+        assertThat(pathConfiguration.properties("$url/not-animated").animated).isFalse()
     }
 
     @Test

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -137,52 +137,11 @@ interface HotwireDestination : BridgeDestination {
         newPathProperties: PathConfigurationProperties,
         action: VisitAction
     ): NavOptions {
-        val navigatingToModalContext = pathProperties.context == PresentationContext.DEFAULT &&
-                newPathProperties.context == PresentationContext.MODAL
-
-        val navigatingWithinModalContext = pathProperties.context == PresentationContext.MODAL &&
-                newPathProperties.context == PresentationContext.MODAL
-
-        val dismissingModalContext = pathProperties.context == PresentationContext.MODAL &&
-                newPathProperties.context == PresentationContext.DEFAULT
-
-        val animate = (navigatingToModalContext || dismissingModalContext) ||
-                (action != VisitAction.REPLACE &&
-                newPathProperties.presentation != Presentation.REPLACE &&
-                newPathProperties.presentation != Presentation.REPLACE_ROOT)
-
-        val clearAll = newPathProperties.presentation == Presentation.CLEAR_ALL
-
-        return if (navigatingToModalContext || navigatingWithinModalContext || dismissingModalContext) {
-            navOptions {
-                anim {
-                    enter = if (animate) R.anim.enter_slide_in_bottom else 0
-                    exit = R.anim.exit_slide_out_bottom
-                    popEnter = R.anim.enter_slide_in_bottom
-                    popExit = R.anim.exit_slide_out_bottom
-                }
-            }
-        } else {
-            if (clearAll) {
-                navOptions {
-                    anim {
-                        enter = R.anim.exit_slide_out_left
-                        exit = R.anim.exit_slide_out_right
-                        popEnter = R.anim.enter_slide_in_left
-                        popExit = R.anim.enter_slide_in_right
-                    }
-                }
-            } else {
-                navOptions {
-                    anim {
-                        enter = if (animate) R.anim.enter_slide_in_right else 0
-                        exit = R.anim.exit_slide_out_left
-                        popEnter = R.anim.enter_slide_in_left
-                        popExit = R.anim.exit_slide_out_right
-                    }
-                }
-            }
-        }
+        return HotwireDestinationAnimations.defaultNavOptions(
+            currentPathProperties = pathProperties,
+            newPathProperties = newPathProperties,
+            action = action
+        )
     }
 
     /**

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestinationAnimations.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestinationAnimations.kt
@@ -3,6 +3,7 @@ package dev.hotwire.navigation.destinations
 import androidx.navigation.NavOptions
 import androidx.navigation.navOptions
 import dev.hotwire.core.turbo.config.PathConfigurationProperties
+import dev.hotwire.core.turbo.config.animated
 import dev.hotwire.core.turbo.config.context
 import dev.hotwire.core.turbo.config.presentation
 import dev.hotwire.core.turbo.nav.Presentation
@@ -73,6 +74,10 @@ class HotwireDestinationAnimations {
             newPathProperties: PathConfigurationProperties,
             action: VisitAction
         ): Boolean {
+            if (!newPathProperties.animated) {
+                return false
+            }
+
             if (navigatingToModalContext || dismissingModalContext) {
                 return true
             }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestinationAnimations.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestinationAnimations.kt
@@ -1,0 +1,85 @@
+package dev.hotwire.navigation.destinations
+
+import androidx.navigation.NavOptions
+import androidx.navigation.navOptions
+import dev.hotwire.core.turbo.config.PathConfigurationProperties
+import dev.hotwire.core.turbo.config.context
+import dev.hotwire.core.turbo.config.presentation
+import dev.hotwire.core.turbo.nav.Presentation
+import dev.hotwire.core.turbo.nav.PresentationContext
+import dev.hotwire.core.turbo.visit.VisitAction
+import dev.hotwire.navigation.R
+
+class HotwireDestinationAnimations {
+    companion object {
+        fun defaultNavOptions(
+            currentPathProperties: PathConfigurationProperties,
+            newPathProperties: PathConfigurationProperties,
+            action: VisitAction
+        ): NavOptions {
+            val navigatingToModalContext = currentPathProperties.context == PresentationContext.DEFAULT &&
+                    newPathProperties.context == PresentationContext.MODAL
+
+            val navigatingWithinModalContext = currentPathProperties.context == PresentationContext.MODAL &&
+                    newPathProperties.context == PresentationContext.MODAL
+
+            val dismissingModalContext = currentPathProperties.context == PresentationContext.MODAL &&
+                    newPathProperties.context == PresentationContext.DEFAULT
+
+            val animate = shouldAnimate(
+                navigatingToModalContext = navigatingToModalContext,
+                dismissingModalContext = dismissingModalContext,
+                newPathProperties = newPathProperties,
+                action = action
+            )
+
+            val clearAll = newPathProperties.presentation == Presentation.CLEAR_ALL
+
+            return if (navigatingToModalContext || navigatingWithinModalContext || dismissingModalContext) {
+                navOptions {
+                    anim {
+                        enter = if (animate) R.anim.enter_slide_in_bottom else 0
+                        exit = R.anim.exit_slide_out_bottom
+                        popEnter = R.anim.enter_slide_in_bottom
+                        popExit = R.anim.exit_slide_out_bottom
+                    }
+                }
+            } else {
+                if (clearAll) {
+                    navOptions {
+                        anim {
+                            enter = R.anim.exit_slide_out_left
+                            exit = R.anim.exit_slide_out_right
+                            popEnter = R.anim.enter_slide_in_left
+                            popExit = R.anim.enter_slide_in_right
+                        }
+                    }
+                } else {
+                    navOptions {
+                        anim {
+                            enter = if (animate) R.anim.enter_slide_in_right else 0
+                            exit = R.anim.exit_slide_out_left
+                            popEnter = R.anim.enter_slide_in_left
+                            popExit = R.anim.exit_slide_out_right
+                        }
+                    }
+                }
+            }
+        }
+
+        private fun shouldAnimate(
+            navigatingToModalContext: Boolean,
+            dismissingModalContext: Boolean,
+            newPathProperties: PathConfigurationProperties,
+            action: VisitAction
+        ): Boolean {
+            if (navigatingToModalContext || dismissingModalContext) {
+                return true
+            }
+
+            return action != VisitAction.REPLACE &&
+                    newPathProperties.presentation != Presentation.REPLACE &&
+                    newPathProperties.presentation != Presentation.REPLACE_ROOT
+        }
+    }
+}


### PR DESCRIPTION
This builds on the changes proposed in: https://github.com/hotwired/hotwire-native-android/pull/104

The destination animation logic has gotten increasingly complex, so this extracts the animation code to its own class. The path configuration `animated` property is now supported, just like the iOS library. Tests have been added to verify the property.