### PR TITLE
Adding onCompletion callback for when path configuration is loaded

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/config/Hotwire.kt
@@ -26,8 +26,9 @@ object Hotwire {
     fun loadPathConfiguration(
         context: Context,
         location: PathConfiguration.Location,
-        options: PathConfiguration.LoaderOptions = PathConfiguration.LoaderOptions()
+        options: PathConfiguration.LoaderOptions = PathConfiguration.LoaderOptions(),
+        onCompletion: (PathConfiguration) -> Unit = {}
     ) {
-        config.pathConfiguration.load(context.applicationContext, location, options)
+        config.pathConfiguration.load(context.applicationContext, location, options, onCompletion)
     }
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -71,7 +71,8 @@ class PathConfiguration {
     fun load(
         context: Context,
         location: Location,
-        options: LoaderOptions
+        options: LoaderOptions,
+        onCompletion: (PathConfiguration) -> Unit = {}
     ) {
         if (loader == null) {
             loader = PathConfigurationLoader(context.applicationContext)
@@ -81,6 +82,7 @@ class PathConfiguration {
             cachedProperties.clear()
             rules = it.rules
             settings = it.settings
+            onCompletion(it)
         }
     }
 

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -126,6 +126,7 @@ class PathConfigurationTest : BaseRepositoryTest() {
 
         runBlocking {
             pathConfiguration.load(context, location, options, onCompletionCallback)
+            verify(mockRepository).getBundledConfiguration(context, assetFilePath)
             verify(mockRepository).getCachedConfigurationForUrl(context, remoteUrl)
             verify(mockRepository).getRemoteConfiguration(remoteUrl, options)
 

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -79,6 +79,65 @@ class PathConfigurationTest : BaseRepositoryTest() {
     }
 
     @Test
+    fun callbackIsInvokedWhenConfigurationIsLoaded() {
+        val localPath = "/not-animated"
+        val cachedPath = "/from-cache"
+        val remotePath = "/from-remote"
+
+        var onCompleteInvocations = 0
+        val onCompletionCallback: (PathConfiguration) -> Unit = { pathConfiguration ->
+            onCompleteInvocations++
+
+            when (onCompleteInvocations) {
+                // See PathConfiguration#load for implementation order of calls, this verifies the correct path is loaded in the correct order
+
+                // First call = loading from asset path
+                1 -> assertThat(pathConfiguration.rules.filter { it.matches(localPath)}.flatMap { it.patterns }.contains(localPath)).isTrue()
+                // Second call = from cache
+                2 -> assertThat(pathConfiguration.rules.filter { it.matches(cachedPath)}.flatMap { it.patterns }.contains(cachedPath)).isTrue()
+                // Third call = from remote
+                3 -> assertThat(pathConfiguration.rules.filter { it.matches(remotePath)}.flatMap { it.patterns }.contains(remotePath)).isTrue()
+            }
+
+        }
+
+        val assetFilePath = "json/test-configuration.json"
+        val remoteUrl = "$url/demo/configurations/android-v1.json"
+        val location = Location(
+            assetFilePath = assetFilePath,
+            remoteFileUrl = remoteUrl
+        )
+        val options = LoaderOptions()
+
+        val assetJson = context.assets.open(assetFilePath).use { String(it.readBytes()) }
+        // Update a value in the JSON to simulate a different configuration
+        val cachedFakeJson = assetJson.replace(localPath, cachedPath)
+        val remoteFakeJson = assetJson.replace(localPath, remotePath)
+
+        // Tell the mock repository to return values for the asset, cached, and remote configurations, changing a field in each to allow for assertion
+        whenever(mockRepository.getBundledConfiguration(context, assetFilePath)).thenReturn(assetJson)
+        whenever(mockRepository.getCachedConfigurationForUrl(context, remoteUrl)).thenReturn(cachedFakeJson)
+        whenever(runBlocking { mockRepository.getRemoteConfiguration(remoteUrl, options)}).thenReturn(remoteFakeJson)
+
+        pathConfiguration = PathConfiguration()
+        pathConfiguration.loader = PathConfigurationLoader(context).apply {
+            repository = mockRepository
+        }
+
+        runBlocking {
+            pathConfiguration.load(context, location, options, onCompletionCallback)
+            verify(mockRepository).getCachedConfigurationForUrl(context, remoteUrl)
+            verify(mockRepository).getRemoteConfiguration(remoteUrl, options)
+
+            // The onComplete callback should be invoked 3 times.
+            // 1 - asset path
+            // 2 - from cache
+            // 3 - from remote
+            assertThat(onCompleteInvocations).isEqualTo(3)
+        }
+    }
+
+    @Test
     fun validConfigurationIsCached() {
         pathConfiguration.loader = PathConfigurationLoader(context).apply {
             repository = mockRepository

--- a/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
@@ -38,7 +38,7 @@ class DemoApplication : Application() {
                 assetFilePath = "json/configuration.json"
             ),
             onCompletion = {
-                Log.i("DemoApplication", "Path configuration loaded: $it")
+                Log.i("DemoApplication", "Path configuration loaded")
             }
         )
 

--- a/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.demo
 
 import android.app.Application
+import android.util.Log
 import dev.hotwire.core.BuildConfig
 import dev.hotwire.core.bridge.BridgeComponentFactory
 import dev.hotwire.core.bridge.KotlinXJsonConverter
@@ -35,7 +36,10 @@ class DemoApplication : Application() {
             context = this,
             location = PathConfiguration.Location(
                 assetFilePath = "json/configuration.json"
-            )
+            ),
+            onCompletion = {
+                Log.i("DemoApplication", "Path configuration loaded: $it")
+            }
         )
 
         // Set the default fragment destination


### PR DESCRIPTION
This PR ads a completion callback mechanism to the path configuration loading. A default implementation is provided so that the existing API surface does not break existing consumers. 

This callback will get invoked anytime the path configuration is loaded. There are three places a path configuration could be loaded from:

1. Local assets
2. Cache
3. Remote Url

The callback is invoked for each configuration is loaded. If all three are successful the `onCompletion` handler will be invoked 3 times. 

A test is included to validate the behavior.

## Use Case
With [Jumpstart Android](https://jumpstartrails.com/android) we have a use case where we update the `settings` block to include tabs. Some users need to update the tabs based upon logged in state of a user (the remote path configuration settings change if the user is logged in). After a successful login, we re-load the path configuration. However we need to know when the path configuration is done loading so that we can perform some actions on the client to check for new settings values.