### PR TITLE
Tweak the RouteDecisionHandler API to return the `Router.Decision` after matching and handling

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandler.kt
@@ -7,8 +7,6 @@ import dev.hotwire.navigation.navigator.NavigatorConfiguration
 class AppNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "app-navigation"
 
-    override val decision = Router.Decision.NAVIGATE
-
     override fun matches(
         location: String,
         configuration: NavigatorConfiguration
@@ -20,7 +18,7 @@ class AppNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
         location: String,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
-    ) {
-        // No-op
+    ): Router.Decision {
+        return Router.Decision.NAVIGATE
     }
 }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserRouteDecisionHandler.kt
@@ -10,8 +10,6 @@ import dev.hotwire.navigation.navigator.NavigatorConfiguration
 class BrowserRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "browser"
 
-    override val decision = Router.Decision.CANCEL
-
     override fun matches(
         location: String,
         configuration: NavigatorConfiguration
@@ -23,7 +21,7 @@ class BrowserRouteDecisionHandler : Router.RouteDecisionHandler {
         location: String,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
-    ) {
+    ): Router.Decision {
         val intent = Intent(Intent.ACTION_VIEW, location.toUri())
 
         try {
@@ -31,5 +29,7 @@ class BrowserRouteDecisionHandler : Router.RouteDecisionHandler {
         } catch (e: ActivityNotFoundException) {
             logError("BrowserRouteDecisionHandler", e)
         }
+
+        return Router.Decision.CANCEL
     }
 }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
@@ -11,8 +11,6 @@ import dev.hotwire.navigation.util.colorFromThemeAttr
 class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "browser-tab"
 
-    override val decision = Router.Decision.CANCEL
-
     override fun matches(
         location: String,
         configuration: NavigatorConfiguration
@@ -24,7 +22,7 @@ class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
         location: String,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
-    ) {
+    ): Router.Decision {
         val color = activity.colorFromThemeAttr(R.attr.colorSurface)
         val colorParams = CustomTabColorSchemeParams.Builder()
             .setToolbarColor(color)
@@ -38,5 +36,7 @@ class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
             .setDefaultColorSchemeParams(colorParams)
             .build()
             .launchUrl(activity, location.toUri())
+
+        return Router.Decision.CANCEL
     }
 }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/Router.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/Router.kt
@@ -22,13 +22,6 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
         val name: String
 
         /**
-         * To permit in-app navigation when the location matches this decision
-         * handler, return [Decision.NAVIGATE]. To prevent in-app navigation
-         * return [Decision.CANCEL].
-         */
-        val decision: Decision
-
-        /**
          * Determines whether the location matches this decision handler. Use
          * your own custom rules based on the location's domain, protocol,
          * path, or any other factors.
@@ -39,14 +32,15 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
         ): Boolean
 
         /**
-         * Handle custom routing behavior when a match is found. For example,
-         * open an external browser or app for external domain urls.
+         * Handle custom routing behavior when a match is found. To continue with in-app
+         * navigation, return [Decision.NAVIGATE]. To prevent in-app navigation return
+         * [Decision.CANCEL].
          */
         fun handle(
             location: String,
             configuration: NavigatorConfiguration,
             activity: HotwireActivity
-        )
+        ): Decision
     }
 
     enum class Decision {
@@ -73,8 +67,7 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
                     "location" to location
                 ))
 
-                handler.handle(location, configuration, activity)
-                return handler.decision
+                return handler.handle(location, configuration, activity)
             }
         }
 

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandlerTest.kt
@@ -1,13 +1,20 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class AppNavigationRouteDecisionHandlerTest {
+    private lateinit var activity: HotwireActivity
+
     private val route = AppNavigationRouteDecisionHandler()
     private val config = NavigatorConfiguration(
         name = "test",
@@ -15,9 +22,15 @@ class AppNavigationRouteDecisionHandlerTest {
         navigatorHostId = 0
     )
 
+    @Before
+    fun setup() {
+        activity = buildActivity(TestActivity::class.java).get()
+    }
+
     @Test
     fun `matching result navigates`() {
-        assertEquals(Router.Decision.NAVIGATE, route.decision)
+        val decision = route.handle(config.startLocation, config, activity)
+        assertEquals(Router.Decision.NAVIGATE, decision)
     }
 
     @Test
@@ -36,5 +49,9 @@ class AppNavigationRouteDecisionHandlerTest {
     fun `masqueraded url does not match`() {
         val url = "https://app.my.com@fake.domain"
         assertFalse(route.matches(url, config))
+    }
+
+    private class TestActivity : HotwireActivity() {
+        override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()
     }
 }

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserRouteDecisionHandlerTest.kt
@@ -1,13 +1,20 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserRouteDecisionHandlerTest {
+    private lateinit var activity: HotwireActivity
+
     private val route = BrowserRouteDecisionHandler()
     private val config = NavigatorConfiguration(
         name = "test",
@@ -15,9 +22,15 @@ class BrowserRouteDecisionHandlerTest {
         navigatorHostId = 0
     )
 
+    @Before
+    fun setup() {
+        activity = buildActivity(TestActivity::class.java).get()
+    }
+
     @Test
     fun `matching result stops navigation`() {
-        assertEquals(Router.Decision.CANCEL, route.decision)
+        val decision = route.handle("https://external.com/page", config, activity)
+        assertEquals(Router.Decision.CANCEL, decision)
     }
 
     @Test
@@ -36,5 +49,9 @@ class BrowserRouteDecisionHandlerTest {
     fun `url on app domain does not match`() {
         val url = "https://my.app.com/page"
         assertFalse(route.matches(url, config))
+    }
+
+    private class TestActivity : HotwireActivity() {
+        override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()
     }
 }

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandlerTest.kt
@@ -1,13 +1,20 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
 class BrowserTabRouteDecisionHandlerTest {
+    private lateinit var activity: HotwireActivity
+
     private val route = BrowserTabRouteDecisionHandler()
     private val config = NavigatorConfiguration(
         name = "test",
@@ -15,9 +22,15 @@ class BrowserTabRouteDecisionHandlerTest {
         navigatorHostId = 0
     )
 
+    @Before
+    fun setup() {
+        activity = buildActivity(TestActivity::class.java).get()
+    }
+
     @Test
     fun `matching result stops navigation`() {
-        assertEquals(Router.Decision.CANCEL, route.decision)
+        val decision = route.handle("https://external.com/page", config, activity)
+        assertEquals(Router.Decision.CANCEL, decision)
     }
 
     @Test
@@ -36,5 +49,9 @@ class BrowserTabRouteDecisionHandlerTest {
     fun `url on app domain does not match`() {
         val url = "https://my.app.com/page"
         assertFalse(route.matches(url, config))
+    }
+
+    private class TestActivity : HotwireActivity() {
+        override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()
     }
 }


### PR DESCRIPTION
This coincides with work in the iOS library in https://github.com/hotwired/hotwire-native-ios/pull/105. To handle more complex scenarios, we need more flexibility to return the route decision *after* running logic in the `handle()` method.

An implemented `RouteDecisionHandler` will now look like:
```kotlin
class BrowserRouteDecisionHandler : Router.RouteDecisionHandler {
    override val name = "browser"

    override fun matches(
        location: String,
        configuration: NavigatorConfiguration
    ): Boolean {
        return configuration.startLocation.toUri().host != location.toUri().host
    }

    override fun handle(
        location: String,
        configuration: NavigatorConfiguration,
        activity: HotwireActivity
    ): Router.Decision {
        val intent = Intent(Intent.ACTION_VIEW, location.toUri())

        try {
            activity.startActivity(intent)
        } catch (e: ActivityNotFoundException) {
            logError("BrowserRouteDecisionHandler", e)
        }

        // New: Decision return value
        return Router.Decision.CANCEL
    }
}
```