### PR TITLE
Add built-in support for recede/refresh/resume historical location urls

### DIFF
--- a/core/src/main/assets/json/test-configuration.json
+++ b/core/src/main/assets/json/test-configuration.json
@@ -67,30 +67,6 @@
     },
     {
       "patterns": [
-        "/custom/recede"
-      ],
-      "properties": {
-        "presentation": "pop"
-      }
-    },
-    {
-      "patterns": [
-        "/custom/refresh"
-      ],
-      "properties": {
-        "presentation": "refresh"
-      }
-    },
-    {
-      "patterns": [
-        "/custom/resume"
-      ],
-      "properties": {
-        "presentation": "none"
-      }
-    },
-    {
-      "patterns": [
         "/custom/modal"
       ],
       "properties": {

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfiguration.kt
@@ -79,7 +79,7 @@ class PathConfiguration {
 
         loader?.load(location, options) {
             cachedProperties.clear()
-            rules = it.rules
+            rules = it.rules + historicalLocationRules
             settings = it.settings
         }
     }
@@ -159,3 +159,6 @@ val PathConfigurationProperties.pullToRefreshEnabled: Boolean
 
 val PathConfigurationProperties.animated: Boolean
     get() = get("animated")?.let { it as Boolean } ?: true
+
+val PathConfigurationProperties.isHistoricalLocation: Boolean
+    get() = get("historical_location")?.let { it as Boolean } ?: false

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationHistoricalLocations.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationHistoricalLocations.kt
@@ -1,0 +1,37 @@
+package dev.hotwire.core.turbo.config
+
+import dev.hotwire.core.turbo.nav.Presentation
+import dev.hotwire.core.turbo.nav.PresentationContext
+
+internal val recedeHistoricalLocationRule = PathConfigurationRule(
+    patterns = listOf("/recede_historical_location"),
+    properties = hashMapOf(
+        "presentation" to Presentation.POP.name,
+        "context" to PresentationContext.DEFAULT.name,
+        "historical_location" to true
+    )
+)
+
+internal val resumeHistoricalLocationRule = PathConfigurationRule(
+    patterns = listOf("/resume_historical_location"),
+    properties = hashMapOf(
+        "presentation" to Presentation.NONE.name,
+        "context" to PresentationContext.DEFAULT.name,
+        "historical_location" to true
+    )
+)
+
+internal val refreshHistoricalLocationRule = PathConfigurationRule(
+    patterns = listOf("/refresh_historical_location"),
+    properties = hashMapOf(
+        "presentation" to Presentation.REFRESH.name,
+        "context" to PresentationContext.DEFAULT.name,
+        "historical_location" to true
+    )
+)
+
+internal val historicalLocationRules = listOf(
+    recedeHistoricalLocationRule,
+    resumeHistoricalLocationRule,
+    refreshHistoricalLocationRule
+)

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationRepositoryTest.kt
@@ -50,7 +50,7 @@ class PathConfigurationRepositoryTest : BaseRepositoryTest() {
         assertThat(json).isNotNull()
 
         val config = load(json)
-        assertThat(config?.rules?.size).isEqualTo(12)
+        assertThat(config?.rules?.size).isGreaterThan(0)
     }
 
     @Test

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -14,6 +14,7 @@ import com.nhaarman.mockito_kotlin.whenever
 import dev.hotwire.core.turbo.BaseRepositoryTest
 import dev.hotwire.core.turbo.config.PathConfiguration.LoaderOptions
 import dev.hotwire.core.turbo.config.PathConfiguration.Location
+import dev.hotwire.core.turbo.nav.Presentation
 import dev.hotwire.core.turbo.nav.PresentationContext
 import dev.hotwire.core.turbo.util.toJson
 import dev.hotwire.core.turbo.util.toObject
@@ -57,7 +58,7 @@ class PathConfigurationTest : BaseRepositoryTest() {
 
     @Test
     fun assetConfigurationIsLoaded() {
-        assertThat(pathConfiguration.rules.size).isEqualTo(12)
+        assertThat(pathConfiguration.rules.size).isGreaterThan(0)
     }
 
     @Test
@@ -138,6 +139,33 @@ class PathConfigurationTest : BaseRepositoryTest() {
                 demoSite = "https://hotwire-native-demo.dev"
             )
         )
+    }
+
+    @Test
+    fun recedeHistoricalLocation() {
+        val properties = pathConfiguration.properties("$url/recede_historical_location")
+
+        assertThat(properties.presentation).isEqualTo(Presentation.POP)
+        assertThat(properties.context).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(properties.isHistoricalLocation).isTrue()
+    }
+
+    @Test
+    fun resumeHistoricalLocation() {
+        val properties = pathConfiguration.properties("$url/resume_historical_location")
+
+        assertThat(properties.presentation).isEqualTo(Presentation.NONE)
+        assertThat(properties.context).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(properties.isHistoricalLocation).isTrue()
+    }
+
+    @Test
+    fun refreshHistoricalLocation() {
+        val properties = pathConfiguration.properties("$url/refresh_historical_location")
+
+        assertThat(properties.presentation).isEqualTo(Presentation.REFRESH)
+        assertThat(properties.context).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(properties.isHistoricalLocation).isTrue()
     }
 
     @Test

--- a/demo/src/main/assets/json/configuration.json
+++ b/demo/src/main/assets/json/configuration.json
@@ -24,22 +24,13 @@
     },
     {
       "patterns": [
-        "/signin$",
+        "/new$",
+        "/modal$",
         "/bridge-form$"
       ],
       "properties": {
         "context": "modal",
         "uri": "hotwire://fragment/web/modal",
-        "pull_to_refresh_enabled": false
-      }
-    },
-    {
-      "patterns": [
-        "/new$"
-      ],
-      "properties": {
-        "context": "modal",
-        "uri": "hotwire://fragment/web/modal/sheet",
         "pull_to_refresh_enabled": false
       }
     },

--- a/demo/src/main/assets/json/configuration.json
+++ b/demo/src/main/assets/json/configuration.json
@@ -24,13 +24,22 @@
     },
     {
       "patterns": [
-        "/new$",
-        "/modal$",
+        "/signin$",
         "/bridge-form$"
       ],
       "properties": {
         "context": "modal",
         "uri": "hotwire://fragment/web/modal",
+        "pull_to_refresh_enabled": false
+      }
+    },
+    {
+      "patterns": [
+        "/new$"
+      ],
+      "properties": {
+        "context": "modal",
+        "uri": "hotwire://fragment/web/modal/sheet",
         "pull_to_refresh_enabled": false
       }
     },

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireFragmentDelegate.kt
@@ -71,7 +71,7 @@ class HotwireFragmentDelegate(private val navDestination: HotwireDestination) {
      */
     fun onStartAfterModalResult(result: SessionModalResult) {
         logEvent("fragment.onStartAfterModalResult", "location" to result.location, "options" to result.options)
-        if (result.shouldNavigate) {
+        if (navigator.shouldRouteToModalResult(result)) {
             navigator.route(result.location, result.options, result.bundle)
         }
     }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -94,7 +94,7 @@ internal class HotwireWebFragmentDelegate(
      * modal result. Will navigate if the result indicates it should.
      */
     fun onStartAfterModalResult(result: SessionModalResult) {
-        if (!result.shouldNavigate) {
+        if (!navigator.shouldRouteToModalResult(result)) {
             initNavigationVisit()
             initWebChromeClient()
         }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -19,6 +19,7 @@ import dev.hotwire.navigation.destinations.HotwireDestination
 import dev.hotwire.navigation.destinations.HotwireDialogDestination
 import dev.hotwire.navigation.logging.logEvent
 import dev.hotwire.navigation.routing.Router
+import dev.hotwire.navigation.session.SessionModalResult
 import dev.hotwire.navigation.util.location
 
 class Navigator(
@@ -70,6 +71,21 @@ class Navigator(
         if (HotwireNavigation.registeredBridgeComponentFactories.isNotEmpty()) {
             Bridge.initialize(it.webView)
         }
+    }
+
+    internal fun shouldRouteToModalResult(result: SessionModalResult): Boolean {
+        val rule = NavigatorRule(
+            location = result.location,
+            visitOptions = result.options,
+            bundle = result.bundle,
+            navOptions = navOptions(result.location, result.options.action),
+            extras = null,
+            pathConfiguration = Hotwire.config.pathConfiguration,
+            navigatorName = configuration.name,
+            controller = currentControllerForLocation(result.location)
+        )
+
+        return rule.newNavigationMode != NavigatorMode.NONE
     }
 
     /**
@@ -152,7 +168,7 @@ class Navigator(
                 navigateWithinContext(rule)
             }
             NavigatorMode.REFRESH -> {
-                route(rule.currentLocation, VisitOptions())
+                route(rule.currentLocation, VisitOptions(action = VisitAction.REPLACE))
             }
             NavigatorMode.NONE -> {
                 // Do nothing

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -146,8 +146,7 @@ internal class NavigatorRule(
         return SessionModalResult(
             location = newLocation,
             options = newVisitOptions.copy(action = action),
-            bundle = newBundle,
-            shouldNavigate = newProperties.presentation != Presentation.NONE
+            bundle = newBundle
         )
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/session/SessionModalResult.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/session/SessionModalResult.kt
@@ -15,6 +15,5 @@ import dev.hotwire.core.turbo.visit.VisitOptions
 data class SessionModalResult(
     val location: String,
     val options: VisitOptions,
-    val bundle: Bundle?,
-    val shouldNavigate: Boolean
+    val bundle: Bundle?
 )

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorRuleTest.kt
@@ -41,9 +41,9 @@ class NavigatorRuleTest {
     private val featureTwoUrl = "https://hotwired.dev/feature-two"
     private val newUrl = "https://hotwired.dev/feature/new"
     private val editUrl = "https://hotwired.dev/feature/edit"
-    private val recedeUrl = "https://hotwired.dev/custom/recede"
-    private val refreshUrl = "https://hotwired.dev/custom/refresh"
-    private val resumeUrl = "https://hotwired.dev/custom/resume"
+    private val recedeUrl = "https://hotwired.dev/recede_historical_location"
+    private val refreshUrl = "https://hotwired.dev/refresh_historical_location"
+    private val resumeUrl = "https://hotwired.dev/resume_historical_location"
     private val modalRootUrl = "https://hotwired.dev/custom/modal"
     private val filterUrl = "https://hotwired.dev/feature?filter=true"
     private val customUrl = "https://hotwired.dev/custom"
@@ -302,7 +302,29 @@ class NavigatorRuleTest {
     }
 
     @Test
-    fun `refresh the current destination`() {
+    fun `recede historical location in default context pops the current destination`() {
+        controller.navigate(webDestinationId, locationArgs(featureUrl))
+        val rule = getNavigatorRule(recedeUrl)
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(homeUrl)
+        assertThat(rule.currentLocation).isEqualTo(featureUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(recedeUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(Presentation.POP)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.DEFAULT)
+        assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.IN_CONTEXT)
+        assertThat(rule.newModalResult).isNull()
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `refresh historical location in default context refreshes the current destination`() {
         controller.navigate(webDestinationId, locationArgs(featureUrl))
         val rule = getNavigatorRule(refreshUrl)
 
@@ -325,7 +347,80 @@ class NavigatorRuleTest {
     }
 
     @Test
-    fun `resume the previous destination after leaving modal context`() {
+    fun `resume historical location in default context does nothing`() {
+        controller.navigate(webDestinationId, locationArgs(featureUrl))
+        val rule = getNavigatorRule(resumeUrl)
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(homeUrl)
+        assertThat(rule.currentLocation).isEqualTo(featureUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(resumeUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(Presentation.NONE)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.DEFAULT)
+        assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.NONE)
+        assertThat(rule.newModalResult).isNull()
+        assertThat(rule.newDestinationUri).isEqualTo(webUri)
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `recede historical location from modal context dismisses with result`() {
+        controller.navigate(webDestinationId, locationArgs(featureUrl))
+        controller.navigate(webModalDestinationId, locationArgs(newUrl))
+        val rule = getNavigatorRule(recedeUrl)
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(featureUrl)
+        assertThat(rule.currentLocation).isEqualTo(newUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(PresentationContext.MODAL)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(recedeUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(Presentation.POP)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.DEFAULT)
+        assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.DISMISS_MODAL)
+        assertThat(rule.newModalResult).isNotNull()
+        assertThat(rule.newModalResult?.location).isEqualTo(recedeUrl)
+        assertThat(rule.newDestinationUri).isEqualTo(webUri)
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `refresh historical location from modal context dismisses with result`() {
+        controller.navigate(webDestinationId, locationArgs(featureUrl))
+        controller.navigate(webModalDestinationId, locationArgs(newUrl))
+        val rule = getNavigatorRule(refreshUrl)
+
+        // Current destination
+        assertThat(rule.previousLocation).isEqualTo(featureUrl)
+        assertThat(rule.currentLocation).isEqualTo(newUrl)
+        assertThat(rule.currentPresentationContext).isEqualTo(PresentationContext.MODAL)
+        assertThat(rule.isAtStartDestination).isFalse()
+
+        // New destination
+        assertThat(rule.newLocation).isEqualTo(refreshUrl)
+        assertThat(rule.newPresentationContext).isEqualTo(PresentationContext.DEFAULT)
+        assertThat(rule.newPresentation).isEqualTo(Presentation.REFRESH)
+        assertThat(rule.newQueryStringPresentation).isEqualTo(QueryStringPresentation.DEFAULT)
+        assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.DISMISS_MODAL)
+        assertThat(rule.newModalResult).isNotNull()
+        assertThat(rule.newModalResult?.location).isEqualTo(refreshUrl)
+        assertThat(rule.newDestinationUri).isEqualTo(webUri)
+        assertThat(rule.newDestination).isNotNull()
+        assertThat(rule.newNavOptions).isEqualTo(navOptions)
+    }
+
+    @Test
+    fun `resume historical location from modal context dismisses with result`() {
         controller.navigate(webDestinationId, locationArgs(featureUrl))
         controller.navigate(webModalDestinationId, locationArgs(newUrl))
         val rule = getNavigatorRule(resumeUrl)
@@ -344,7 +439,6 @@ class NavigatorRuleTest {
         assertThat(rule.newNavigationMode).isEqualTo(NavigatorMode.DISMISS_MODAL)
         assertThat(rule.newModalResult).isNotNull()
         assertThat(rule.newModalResult?.location).isEqualTo(resumeUrl)
-        assertThat(rule.newModalResult?.shouldNavigate).isFalse()
         assertThat(rule.newDestinationUri).isEqualTo(webUri)
         assertThat(rule.newDestination).isNotNull()
         assertThat(rule.newNavOptions).isEqualTo(navOptions)


### PR DESCRIPTION
This is the Android equivalent of the iOS changes here: https://github.com/hotwired/hotwire-native-ios/pull/76

### Context
[Turbo Native](https://native.hotwired.dev/reference/navigation#server-driven-routing-in-rails) allows server-driven routing in Rails applications. Previously, developers had to explicitly define these routing rules in the path config. This PR adds default routing rules for server-driven navigation directly into the framework.

### Changes
- recede, resume and refresh historical location rules (historical location rules) have been added as `PathConfigurationRule`s.
- historical location rules are now loaded by default whether or not the source of the path config is provided.

### Historical Location Behaviour

**resume_historical_location**
1. Dismiss the modal destination.
2. Arrive back at the destination on the "default" stack.

**refresh_historical_location**
1. Dismiss the modal destination.
2. Arrive back at the destination on the "default" stack.
3. Refresh the destination no the "default" stack by revisiting the location.

**recede_historical_location**
1. Dismiss the modal destination.
2. Arrive back at the destination on the "default" stack.
3. Pop the destination on the "default" stack (unless it's already at the beginning of the backstack).
4. This will trigger a refresh on the appeared destination if the snapshot cache has been cleared by a form submission.