### PR TITLE
Improve the external route decision handlers

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
@@ -59,12 +59,6 @@ class DemoApplication : Application() {
             BridgeComponentFactory("overflow-menu", ::OverflowMenuComponent)
         )
 
-        // Register route decision handlers
-        Hotwire.registerRouteDecisionHandlers(
-            AppNavigationRouteDecisionHandler(),
-            BrowserTabRouteDecisionHandler()
-        )
-
         // Set configuration options
         Hotwire.config.debugLoggingEnabled = BuildConfig.DEBUG
         Hotwire.config.webViewDebuggingEnabled = BuildConfig.DEBUG

--- a/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/DemoApplication.kt
@@ -19,9 +19,6 @@ import dev.hotwire.demo.features.web.WebModalFragment
 import dev.hotwire.navigation.config.defaultFragmentDestination
 import dev.hotwire.navigation.config.registerBridgeComponents
 import dev.hotwire.navigation.config.registerFragmentDestinations
-import dev.hotwire.navigation.config.registerRouteDecisionHandlers
-import dev.hotwire.navigation.routing.AppNavigationRouteDecisionHandler
-import dev.hotwire.navigation.routing.BrowserTabRouteDecisionHandler
 
 class DemoApplication : Application() {
     override fun onCreate() {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/config/HotwireNavigation.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/config/HotwireNavigation.kt
@@ -8,14 +8,16 @@ import dev.hotwire.navigation.destinations.HotwireDestination
 import dev.hotwire.navigation.fragments.HotwireWebBottomSheetFragment
 import dev.hotwire.navigation.fragments.HotwireWebFragment
 import dev.hotwire.navigation.routing.AppNavigationRouteDecisionHandler
-import dev.hotwire.navigation.routing.BrowserRouteDecisionHandler
+import dev.hotwire.navigation.routing.BrowserTabRouteDecisionHandler
+import dev.hotwire.navigation.routing.SystemNavigationRouteDecisionHandler
 import dev.hotwire.navigation.routing.Router
 import kotlin.reflect.KClass
 
 internal object HotwireNavigation {
     var router = Router(listOf(
         AppNavigationRouteDecisionHandler(),
-        BrowserRouteDecisionHandler()
+        BrowserTabRouteDecisionHandler(),
+        SystemNavigationRouteDecisionHandler()
     ))
 
     var defaultFragmentDestination: KClass<out Fragment> = HotwireWebFragment::class

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandler.kt
@@ -4,6 +4,9 @@ import androidx.core.net.toUri
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 
+/**
+ * Navigates internal urls through in-app routing.
+ */
 class AppNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "app-navigation"
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
@@ -24,8 +24,8 @@ class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
     ): Boolean {
         val locationUri = location.toUri()
 
-        return configuration.startLocation.toUri().host != location.toUri().host &&
-                (locationUri.scheme == "https" || locationUri.scheme == "http")
+        return configuration.startLocation.toUri().host != locationUri.host &&
+                (locationUri.scheme?.lowercase() == "https" || locationUri.scheme?.lowercase() == "http")
     }
 
     override fun handle(

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
@@ -8,6 +8,13 @@ import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 import dev.hotwire.navigation.util.colorFromThemeAttr
 
+/**
+ * Opens external HTTP/S urls via a browser Custom Tab so the user
+ * stays in-app. If the device default browser does not support
+ * Custom Tabs, the url will open directly in the default browser.
+ *
+ * https://developer.chrome.com/docs/android/custom-tabs
+ */
 class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "browser-tab"
 
@@ -15,7 +22,10 @@ class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
         location: String,
         configuration: NavigatorConfiguration
     ): Boolean {
-        return configuration.startLocation.toUri().host != location.toUri().host
+        val locationUri = location.toUri()
+
+        return configuration.startLocation.toUri().host != location.toUri().host &&
+                (locationUri.scheme == "https" || locationUri.scheme == "http")
     }
 
     override fun handle(

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandler.kt
@@ -30,7 +30,7 @@ class SystemNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
         try {
             activity.startActivity(intent)
         } catch (e: ActivityNotFoundException) {
-            logError("BrowserRouteDecisionHandler", e)
+            logError("SystemNavigationRouteDecisionHandler", e)
         }
 
         return Router.Decision.CANCEL

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandler.kt
@@ -7,8 +7,11 @@ import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.logging.logError
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 
-class BrowserRouteDecisionHandler : Router.RouteDecisionHandler {
-    override val name = "browser"
+/**
+ * Opens external urls via a new Activity intent. Non-HTTP/S schemes are supported.
+ */
+class SystemNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
+    override val name = "system-navigation"
 
     override fun matches(
         location: String,

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandlerTest.kt
@@ -51,6 +51,12 @@ class BrowserTabRouteDecisionHandlerTest {
         assertFalse(route.matches(url, config))
     }
 
+    @Test
+    fun `non-http scheme does not match`() {
+        val url = "sms:555-555-5555"
+        assertFalse(route.matches(url, config))
+    }
+
     private class TestActivity : HotwireActivity() {
         override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()
     }

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandlerTest.kt
@@ -12,10 +12,10 @@ import org.robolectric.Robolectric.buildActivity
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-class BrowserRouteDecisionHandlerTest {
+class SystemNavigationRouteDecisionHandlerTest {
     private lateinit var activity: HotwireActivity
 
-    private val route = BrowserRouteDecisionHandler()
+    private val route = SystemNavigationRouteDecisionHandler()
     private val config = NavigatorConfiguration(
         name = "test",
         startLocation = "https://my.app.com",
@@ -49,6 +49,12 @@ class BrowserRouteDecisionHandlerTest {
     fun `url on app domain does not match`() {
         val url = "https://my.app.com/page"
         assertFalse(route.matches(url, config))
+    }
+
+    @Test
+    fun `non-http scheme matches`() {
+        val url = "sms:555-555-5555"
+        assertTrue(route.matches(url, config))
     }
 
     private class TestActivity : HotwireActivity() {


### PR DESCRIPTION
This aligns the external route decision handlers in https://github.com/hotwired/hotwire-native-ios/pull/105:
- `BrowserTabRouteDecisionHandler`: Opens external HTTP/S urls via a [browser Custom Tab](https://developer.chrome.com/docs/android/custom-tabs) so the user stays in-app. If the device default browser does not support Custom Tabs, the url will open directly in the default browser.
- `SystemNavigationRouteDecisionHandler`: Opens external urls via a new Activity intent. Non-HTTP/S schemes are supported.