### PR TITLE
Expose the `onVisitRequestFinished()` callback for apps

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -381,6 +381,12 @@ class Session(
     @JavascriptInterface
     fun visitRequestFinished(visitIdentifier: String) {
         logEvent("visitRequestFinished", "visitIdentifier" to visitIdentifier)
+
+        currentVisit?.let { visit ->
+            if (visitIdentifier == visit.identifier) {
+                callback { it.visitRequestFinished() }
+            }
+        }
     }
 
     /**

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/SessionCallback.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/SessionCallback.kt
@@ -16,6 +16,7 @@ interface SessionCallback {
     fun requestFailedWithError(visitHasCachedSnapshot: Boolean, error: VisitError)
     fun onReceivedHttpAuthRequest(handler: HttpAuthHandler, host: String, realm: String)
     fun visitRendered()
+    fun visitRequestFinished()
     fun visitCompleted(completedOffline: Boolean)
     fun visitLocationStarted(location: String)
     fun visitProposedToLocation(location: String, options: VisitOptions)

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentCallback.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentCallback.kt
@@ -65,6 +65,11 @@ interface HotwireWebFragmentCallback {
     fun onVisitRendered(location: String) {}
 
     /**
+     * Called when a Turbo visit request has finished.
+     */
+    fun onVisitRequestFinished(location: String) {}
+
+    /**
      * Called when a Turbo visit has completed.
      */
     fun onVisitCompleted(location: String, completedOffline: Boolean) {}

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -209,6 +209,10 @@ internal class HotwireWebFragmentDelegate(
         removeTransitionalViews()
     }
 
+    override fun visitRequestFinished() {
+        callback.onVisitRequestFinished(location)
+    }
+
     override fun visitCompleted(completedOffline: Boolean) {
         callback.onVisitCompleted(location, completedOffline)
         navDestination.fragmentViewModel.setTitle(title())


### PR DESCRIPTION
This brings parity to the iOS changes in: https://github.com/hotwired/hotwire-native-ios/pull/119