### PR TITLE
KotlinX serialization improvements

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
@@ -41,8 +41,9 @@ abstract class BridgeComponentJsonTypeConverter : BridgeComponentJsonConverter()
     abstract fun <T> toJson(data: T, type: Class<T>): String
 }
 
-class KotlinXJsonConverter : BridgeComponentJsonConverter() {
-    val json = Json { ignoreUnknownKeys = true }
+class KotlinXJsonConverter(
+    val json: Json = Json { ignoreUnknownKeys = true }
+) : BridgeComponentJsonConverter() {
 
     inline fun <reified T> toObject(jsonData: String): T? {
         return try {

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
@@ -42,7 +42,10 @@ abstract class BridgeComponentJsonTypeConverter : BridgeComponentJsonConverter()
 }
 
 class KotlinXJsonConverter(
-    val json: Json = Json { ignoreUnknownKeys = true }
+    val json: Json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+    }
 ) : BridgeComponentJsonConverter() {
 
     inline fun <reified T> toObject(jsonData: String): T? {


### PR DESCRIPTION
This PR adds two small (backwards-compatible) improvements to the default KotlinX Serialization implementation:

- possibility to provide a custom Json instance through `KotlinXJsonConverter`'s constructor (for providing custom options)
- adding `encodeDefaults = true` as default which ensures default parameter values are not ignored for serialization (even though this is the default we most probably always want, this change should be noted in release notes)