### PR TITLE
Update the web bridge reference to match hotwire-native-bridge `v1.2+`

### DIFF
--- a/core/src/main/assets/js/bridge_components.js
+++ b/core/src/main/assets/js/bridge_components.js
@@ -84,11 +84,13 @@
     // Web global
 
     get isBridgeAvailable() {
-      return window.Strada
+      // Fallback to Strada for legacy Strada web JavaScript.
+      return window.HotwireNative ?? window.Strada
     }
 
     get webBridge() {
-      return window.Strada.web
+      // Fallback to Strada for legacy Strada web JavaScript.
+      return window.HotwireNative?.web ?? window.Strada.web
     }
   }
 


### PR DESCRIPTION
This updates the web bridge global to prefer `window.HotwireNative` over `window.Strada`. The corresponding change was made in: **hotwire-native-bridge** `1.2`:

- PR: https://github.com/hotwired/hotwire-native-bridge/pull/7
- Release: https://github.com/hotwired/hotwire-native-bridge/releases/tag/v1.2.0