### PR TITLE
Crash and bug fixes (with nullable API changes)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,8 +2,8 @@
 plugins {
     id("com.android.application") version "8.9.1" apply false
     id("com.android.library") version "8.9.1" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
-    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.20" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "2.1.20" apply false
 }
 
 tasks.register<Delete>("clean").configure {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id("com.android.application") version "8.7.3" apply false
-    id("com.android.library") version "8.7.3" apply false
+    id("com.android.application") version "8.9.1" apply false
+    id("com.android.library") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.0" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.0" apply false
 }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -75,7 +75,7 @@ android {
 
 dependencies {
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-reflect:2.1.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:2.1.20")
 
     // Material
     implementation("com.google.android.material:material:1.12.0")

--- a/core/src/main/assets/json/test-configuration.json
+++ b/core/src/main/assets/json/test-configuration.json
@@ -1,6 +1,7 @@
 {
   "settings": {
     "custom_app_feature_enabled": true,
+    "custom_app_number": 1,
     "custom_app_data": {
       "marketing_site": "https://native.hotwired.dev",
       "demo_site": "https://hotwire-native-demo.dev"

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/util/CoreExtensions.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/util/CoreExtensions.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.webkit.WebResourceRequest
 import com.google.gson.Gson
 import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
 import dev.hotwire.core.turbo.visit.VisitAction
 import dev.hotwire.core.turbo.visit.VisitActionAdapter
@@ -71,4 +72,5 @@ internal fun <T> String.toObject(typeToken: TypeToken<T>): T {
 
 private val gson: Gson = GsonBuilder()
     .registerTypeAdapter(VisitAction::class.java, VisitActionAdapter())
+    .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
     .create()

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -130,9 +130,10 @@ class PathConfigurationTest : BaseRepositoryTest() {
 
     @Test
     fun globalSetting() {
-        assertThat(pathConfiguration.settings.size).isEqualTo(2)
+        assertThat(pathConfiguration.settings.size).isEqualTo(3)
         assertThat(pathConfiguration.settings["no_such_key"]).isNull()
         assertThat(pathConfiguration.settings["custom_app_feature_enabled"]).isEqualTo(true)
+        assertThat(pathConfiguration.settings["custom_app_number"] as Long).isEqualTo(1)
         assertThat(pathConfiguration.settings.getCustomAppData()).isEqualTo(
             CustomAppData(
                 marketingSite = "https://native.hotwired.dev",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/navigation-fragments/build.gradle.kts
+++ b/navigation-fragments/build.gradle.kts
@@ -78,7 +78,7 @@ dependencies {
     implementation(project(":core"))
 
     // Kotlin
-    implementation("org.jetbrains.kotlin:kotlin-reflect:2.1.0")
+    implementation("org.jetbrains.kotlin:kotlin-reflect:2.1.20")
 
     // AndroidX
     implementation("androidx.constraintlayout:constraintlayout:2.2.0")

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
@@ -100,7 +100,7 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
      * @return The [NavigatorHost] instance if it's view has been created and it has
      *  been registered with the Activity, otherwise `null`.
      */
-    fun navigatorHost(@IdRes navigatorHostId: Int): NavigatorHost? {
+    fun findNavigatorHost(@IdRes navigatorHostId: Int): NavigatorHost? {
         return navigatorHosts[navigatorHostId]
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
@@ -45,10 +45,10 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
      */
     val currentNavigator: Navigator?
         get() {
-            val navigator = navigatorHosts[currentNavigatorHostId]
+            val host = navigatorHosts[currentNavigatorHostId]
 
-            return if (navigator?.isReady() == true) {
-                navigator.navigator
+            return if (host?.isReady() == true) {
+                host.navigator
             } else {
                 null
             }
@@ -94,15 +94,14 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
     }
 
     /**
-     * Finds the navigator host associated with the provided resource ID.
+     * Finds the registered navigator host associated with the provided resource ID.
      *
      * @param navigatorHostId
-     * @return
+     * @return The [NavigatorHost] instance if it's view has been created and it has
+     *  been registered with the Activity, otherwise `null`.
      */
-    fun navigatorHost(@IdRes navigatorHostId: Int): NavigatorHost {
-        return requireNotNull(navigatorHosts[navigatorHostId]) {
-            "No registered NavigatorHost found"
-        }
+    fun navigatorHost(@IdRes navigatorHostId: Int): NavigatorHost? {
+        return navigatorHosts[navigatorHostId]
     }
 
     /**

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -105,43 +105,39 @@ interface HotwireDestination : BridgeDestination {
     fun refresh(displayProgress: Boolean = true)
 
     /**
-     * Gets the navigator that will be used for navigating to `newLocation`. You should
-     * not have to override this, unless you're using a [NestedNavigatorHostDelegate] to provide
-     * sub-navigation within your current Fragment destination and would like custom behavior.
+     * Override if you're using a [NestedNavigatorHostDelegate] to provide sub-navigation
+     * within your current Fragment destination and would like custom behavior.
+     *
+     * Return `null` to use the default `navigator` instance for navigation.
      */
-    fun navigatorForNavigation(newLocation: String): Navigator {
-        return navigator
+    fun customNavigatorForNavigation(newLocation: String): Navigator? {
+        return null
     }
 
     /**
-     * Determines whether the new location should be routed within in-app navigation from the
-     * current destination. By default, the registered [Router.RouteDecisionHandler] instances are used to
-     * determine routing logic. You can override the global behavior for a specific destination,
-     * but it's recommend to use dedicated [Router.RouteDecisionHandler] instances for routing logic.
+     * Override to provide a custom `Router.Decision` from your destination. By default, the
+     * registered [Router.RouteDecisionHandler] instances are used to determine routing logic.
+     * It's recommend to use dedicated [Router.RouteDecisionHandler] instances for routing logic.
+     *
+     * Return `null` to use the global [Router.RouteDecisionHandler] instances to determine
+     * routing logic.
      */
-    fun decideRoute(newLocation: String): Router.Decision {
-        return HotwireNavigation.router.decideRoute(
-            location = newLocation,
-            configuration = navigator.configuration,
-            activity = fragment.requireActivity() as HotwireActivity
-        )
+    fun customRouteDecision(newLocation: String): Router.Decision? {
+        return null
     }
 
     /**
-     * Gets the default set of navigation options (basic enter/exit animations) for the Android
-     * Navigation component to use to execute a navigation event. This can be overridden if
-     * you'd like to provide your own.
+     * Override to provide a custom set of navigation options (basic enter/exit animations)
+     * for the Android Navigation component to use to execute a navigation event.
+     *
+     * Return `null` to use the library's default destination animations.
      */
-    fun getNavigationOptions(
+    fun customNavigationOptions(
         newLocation: String,
         newPathProperties: PathConfigurationProperties,
         action: VisitAction
-    ): NavOptions {
-        return HotwireDestinationAnimations.defaultNavOptions(
-            currentPathProperties = pathProperties,
-            newPathProperties = newPathProperties,
-            action = action
-        )
+    ): NavOptions? {
+        return null
     }
 
     /**

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -2,7 +2,6 @@ package dev.hotwire.navigation.navigator
 
 import android.os.Bundle
 import androidx.annotation.IdRes
-import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
@@ -220,11 +219,14 @@ class Navigator(
     }
 
     /**
-     * Finds the [NavigatorHost] with the given resource ID.
+     * Finds the registered navigator host associated with the provided resource ID.
+     *
+     * @param navigatorHostId
+     * @return The [NavigatorHost] instance if it's view has been created and it has
+     *  been registered with the Activity, otherwise `null`.
      */
-    fun findNavigatorHost(@IdRes navigatorHostId: Int): NavigatorHost {
-        return activity.supportFragmentManager.findNavigatorHost(navigatorHostId)
-            ?: throw IllegalStateException("No NavigatorHost found with ID: $navigatorHostId")
+    fun findNavigatorHost(@IdRes navigatorHostId: Int): NavigatorHost? {
+        return activity.delegate.findNavigatorHost(navigatorHostId)
     }
 
     private fun navigateWhenReady(onReady: () -> Unit) {
@@ -455,10 +457,6 @@ class Navigator(
         sessionName = configuration.name,
         activity = activity
     )
-
-    private fun FragmentManager.findNavigatorHost(navigatorHostId: Int): NavigatorHost? {
-        return findFragmentById(navigatorHostId) as? NavigatorHost
-    }
 
     private val NavBackStackEntry?.isModalContext: Boolean
         get() = this?.arguments?.presentationContext == PresentationContext.MODAL

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -20,7 +20,7 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
         super.onCreate(savedInstanceState)
 
         activity = requireActivity() as HotwireActivity
-        navigator = Navigator(this, configuration)
+        navigator = Navigator(this, configuration, activity)
         childFragmentManager.addFragmentOnAttachListener(this)
 
         initControllerGraph()

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -41,7 +41,7 @@ internal class NavigatorRule(
     // Current destination
     val previousLocation = controller.previousBackStackEntry.location
     val currentLocation = controller.currentBackStackEntry.location
-    val currentProperties = currentLocation?.let { pathConfiguration.properties(currentLocation) }
+    val currentProperties = currentLocation?.let { pathConfiguration.properties(it) }
     val currentPresentationContext = currentProperties?.context ?: PresentationContext.DEFAULT
     val isAtStartDestination = controller.previousBackStackEntry == null
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorRule.kt
@@ -40,9 +40,9 @@ internal class NavigatorRule(
 
     // Current destination
     val previousLocation = controller.previousBackStackEntry.location
-    val currentLocation = checkNotNull(controller.currentBackStackEntry.location)
-    val currentProperties = pathConfiguration.properties(currentLocation)
-    val currentPresentationContext = currentProperties.context
+    val currentLocation = controller.currentBackStackEntry.location
+    val currentProperties = currentLocation?.let { pathConfiguration.properties(currentLocation) }
+    val currentPresentationContext = currentProperties?.context ?: PresentationContext.DEFAULT
     val isAtStartDestination = controller.previousBackStackEntry == null
 
     // New destination
@@ -180,8 +180,8 @@ internal class NavigatorRule(
             return false
         }
 
-        val firstUri = Uri.parse(first)
-        val secondUri = Uri.parse(second)
+        val firstUri = first.toUri()
+        val secondUri = second.toUri()
 
         return when (newQueryStringPresentation) {
             QueryStringPresentation.REPLACE -> {


### PR DESCRIPTION
This addresses the following issues:
- `navigator.currentDestination` no longer throws an exception when an active destination is not found. It is now nullable.
- `activity.delegate.findNavigatorHost(id)` no longer throws an exception when the `NavigatorHost` is not registered. It is now nullable.
- `navigator.findNavigatorHost(id)` no longer throws an exception when the `NavigatorHost` is not registered. It is now nullable.
- Fixes Gson's default number strategy so `Long` values are preferred over `Double` in path configuration parsing.


Additionally, the following APIs have changed:
- `destination.decideRoute()` has been renamed to `destination.customRouteDecision()`. Returning `null` falls back to the default behavior.
- `destination.navigatorForNavigation()` has been renamed to `destination.customNavigatorForNavigation()`. Returning `null` falls back to the default behavior.
- `destination.getNavigationOptions()` has been renamed to `destination.customNavigatorForNavigation()`. Returning `null` falls back to the default behavior.

This includes the following dependency upgrades:
- Android Gradle Plugin has been updated to `8.9.1`
- Kotlin dependencies have been updated to `2.1.20`