### PR TITLE
KotlinX Serialization: disable explicit nulls option

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
@@ -42,11 +42,7 @@ abstract class BridgeComponentJsonTypeConverter : BridgeComponentJsonConverter()
 }
 
 class KotlinXJsonConverter(
-    val json: Json = Json {
-        ignoreUnknownKeys = true
-        encodeDefaults = true
-        explicitNulls = false
-    }
+    val json: Json = dev.hotwire.core.bridge.json
 ) : BridgeComponentJsonConverter() {
 
     inline fun <reified T> toObject(jsonData: String): T? {

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentJsonConverter.kt
@@ -45,6 +45,7 @@ class KotlinXJsonConverter(
     val json: Json = Json {
         ignoreUnknownKeys = true
         encodeDefaults = true
+        explicitNulls = false
     }
 ) : BridgeComponentJsonConverter() {
 

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/JsonExtensions.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/JsonExtensions.kt
@@ -27,7 +27,7 @@ internal inline fun <reified T> String.decode(): T? = try {
     null
 }
 
-private val json = Json {
+internal val json = Json {
     ignoreUnknownKeys = true
     encodeDefaults = true
     explicitNulls = false

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/JsonExtensions.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/JsonExtensions.kt
@@ -27,4 +27,8 @@ internal inline fun <reified T> String.decode(): T? = try {
     null
 }
 
-private val json = Json { ignoreUnknownKeys = true }
+private val json = Json {
+    ignoreUnknownKeys = true
+    encodeDefaults = true
+    explicitNulls = false
+}

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/MessageTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/MessageTest.kt
@@ -49,6 +49,23 @@ class MessageTest {
     }
 
     @Test
+    fun dataWithNullableFieldsDecodesToObject() {
+        val metadata = Metadata("https://37signals.com")
+        val message = Message(
+            id = "1",
+            component = "page",
+            event = "connect",
+            metadata = metadata,
+            jsonData = """{"title":null,"}""" // subtitle missing
+        )
+
+        val data = message.data<MessageData>()
+
+        assertEquals(null, data?.title)
+        assertEquals(null, data?.subtitle)
+    }
+
+    @Test
     fun replacingJsonData() {
         val metadata = Metadata("https://37signals.com")
         val message = Message(
@@ -136,6 +153,9 @@ class MessageTest {
 
     @Serializable
     private class MessageData(val title: String, val subtitle: String)
+
+    @Serializable
+    private class NullableMessageData(val title: String?, val subtitle: String? = null)
 
     private class InvalidMessageData()
 

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/MessageTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/MessageTest.kt
@@ -4,6 +4,7 @@ import dev.hotwire.core.config.Hotwire
 import kotlinx.serialization.Serializable
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Before
 import org.junit.Test
@@ -56,11 +57,12 @@ class MessageTest {
             component = "page",
             event = "connect",
             metadata = metadata,
-            jsonData = """{"title":null,"}""" // subtitle missing
+            jsonData = """{"title":null}""" // subtitle missing
         )
 
         val data = message.data<NullableMessageData>()
 
+        assertNotNull(data)
         assertEquals(null, data?.title)
         assertEquals(null, data?.subtitle)
     }
@@ -78,6 +80,7 @@ class MessageTest {
 
         val data = message.data<DefaultValuesMessageData>()
 
+        assertNotNull(data)
         assertEquals("Page-title", data?.title)
         assertEquals("Page-subtitle", data?.subtitle)
     }

--- a/core/src/test/kotlin/dev/hotwire/core/bridge/MessageTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/bridge/MessageTest.kt
@@ -59,10 +59,27 @@ class MessageTest {
             jsonData = """{"title":null,"}""" // subtitle missing
         )
 
-        val data = message.data<MessageData>()
+        val data = message.data<NullableMessageData>()
 
         assertEquals(null, data?.title)
         assertEquals(null, data?.subtitle)
+    }
+
+    @Test
+    fun dataWithDefaultValuesDecodesToObject() {
+        val metadata = Metadata("https://37signals.com")
+        val message = Message(
+            id = "1",
+            component = "page",
+            event = "connect",
+            metadata = metadata,
+            jsonData = """{}""" // title and subtitle missing
+        )
+
+        val data = message.data<DefaultValuesMessageData>()
+
+        assertEquals("Page-title", data?.title)
+        assertEquals("Page-subtitle", data?.subtitle)
     }
 
     @Test
@@ -156,6 +173,12 @@ class MessageTest {
 
     @Serializable
     private class NullableMessageData(val title: String?, val subtitle: String? = null)
+
+    @Serializable
+    private class DefaultValuesMessageData(
+        val title: String? = "Page-title",
+        val subtitle: String? = "Page-subtitle"
+    )
 
     private class InvalidMessageData()
 


### PR DESCRIPTION
Related to the previous PR: https://github.com/hotwired/hotwire-native-android/pull/128, this one adds a new default option, disabling KotlinX Serialization `explicitNulls`.
When de-serializing JSON which is missing a nullable property a MissingFieldException is thrown instead of being deserialized with a null value (which is what we'd expect in most cases). This option makes sure the default null value for optional properties (nullable) is used.