### PR TITLE
Fixed bottom bar visibility issue

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
@@ -172,6 +172,10 @@ class HotwireBottomNavigationController(
 
     private fun applyWindowInsets() {
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
+            if (!v.isShown) {
+                return@setOnApplyWindowInsetsListener insets
+            }
+
             insets.getInsets(WindowInsetsCompat.Type.systemBars()).apply {
                 v.setPadding(left, 0, right, bottom)
             }


### PR DESCRIPTION
I would like to be able to hide the bottom bar dynamically. For example, if the user isn't signed in I might wish to hide the bar and then display the bar after the user has signed in. I would expect something like the following code to work inside a `HotwireWebFragment` fragment that corresponds to the sign in page:

```kotlin
override fun onVisitCompleted(location: String, completedOffline: Boolean) {
    super.onVisitCompleted(location, completedOffline)
    val hotwireActivity = this.activity as MainActivity
    val bottomNav = hotwireActivity.findViewById<BottomNavigationView>(R.id.bottom_nav)

    if(location.endsWith("login")) {
        bottomNav.visibility = View.GONE
    }
    else {
        bottomNav.visibility = View.VISIBLE
    }
}

```

The code executes but it doesn't work. An adjustment to the private `applyWindowInsets` method of the `BottomNavigationController` object fixes the problem: 

```kotlin
private fun applyWindowInsets() {
    ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
        if (!v.isShown) {
            return@setOnApplyWindowInsetsListener insets
        }
        insets.getInsets(WindowInsetsCompat.Type.systemBars()).apply {
            v.setPadding(left, 0, right, bottom)
        }
        keyboardVisible = insets.isVisible(WindowInsetsCompat.Type.ime())
        insets
    }
}
```

A simple check of the `isShown` property exits the function and prevents the offending code from running.