### PR TITLE
Migrate to OSSRH Staging API

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -187,7 +187,10 @@ publishing {
     repositories {
         if (isSonatypeRelease) {
             maven {
-                url = uri("https://s01.oss.sonatype.org/content/repositories/releases/")
+                // Temporarily switching to Sonatype OSSRH Staging API
+                // until the maven-publish plugin adds support for the new Central Portal
+                // see: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
+                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
 
                 credentials {
                     username = System.getenv("SONATYPE_USER")


### PR DESCRIPTION
As OSSRH is being discontinued on June 30th, we're [migrating to Maven Central Portal](https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/). However, because the Gradle maven-publish plugin doesn't support Central Portal yet, we're using [Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) with the current version of the maven-publish plugin temporarily.