### PR TITLE
Migrate to maven central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,5 +19,6 @@ jobs:
 
       - name: Publish artifact to GitHub Packages
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: ./gradlew -Pversion=${{ github.event.release.tag_name }} clean build -x test publish --stacktrace
+          ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ secrets.GITHUB_ACTOR }}
+          ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew -Pversion=${{ github.event.release.tag_name }} clean build -x test publishAllPublicationsToGithubPackagesRepository --stacktrace

--- a/.github/workflows/sonatype.yml
+++ b/.github/workflows/sonatype.yml
@@ -1,4 +1,4 @@
-name: Publish to Sonatype
+name: Publish to Maven Central
 
 on:
   release:
@@ -17,11 +17,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Publish artifact to Sonatype
+      - name: Publish artifact to Maven Central
         env:
-          SONATYPE_USER: ${{ secrets.SONATYPE_USER }}
-          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
-          GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
-          GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-        run: ./gradlew -Psonatype -Pversion=${{ github.event.release.tag_name }} clean build -x test publish
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USER }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.GPG_KEY_ID }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_SECRET_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSWORD }}
+        run: ./gradlew -Pversion=${{ github.event.release.tag_name }} clean build -x test publishAndReleaseToMavenCentral --no-configuration-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.android.library") version "8.9.1" apply false
     id("org.jetbrains.kotlin.android") version "2.1.20" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "2.1.20" apply false
+    id("com.vanniktech.maven.publish") version "0.32.0" apply false
 }
 
 tasks.register<Delete>("clean").configure {

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -23,8 +23,6 @@ val licenseUrl by extra("https://github.com/hotwired/hotwire-native-android/blob
 val developerId by extra("basecamp")
 val developerEmail by extra("androidteam@basecamp.com")
 
-val isSonatypeRelease by extra(project.hasProperty("sonatype"))
-
 android {
     namespace = "dev.hotwire.core"
     compileSdk = 35
@@ -123,7 +121,7 @@ java {
 // Publish to Maven Central via:
 //   ./gradlew -Pversion=<version> clean build publishAndReleaseToMavenCentral --no-configuration-cache
 //   expected env variables: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
-//   https://search.maven.org/artifact/dev.hotwire/core
+//   https://central.sonatype.com/artifact/dev.hotwire/core
 
 mavenPublishing {
     coordinates(groupId = publishedGroupId, artifactId = publishedArtifactId, version = libVersionName)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     id("org.jetbrains.kotlin.plugin.serialization")
-    id("com.vanniktech.maven.publish") version "0.32.0"
+    id("com.vanniktech.maven.publish")
 }
 
 val libVersionName by extra(version as String)

--- a/navigation-fragments/build.gradle.kts
+++ b/navigation-fragments/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
-    id("com.vanniktech.maven.publish") version "0.32.0"
+    id("com.vanniktech.maven.publish")
 }
 
 val libVersionName by extra(version as String)

--- a/navigation-fragments/build.gradle.kts
+++ b/navigation-fragments/build.gradle.kts
@@ -1,8 +1,9 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
-    id("maven-publish")
-    id("signing")
+    id("com.vanniktech.maven.publish") version "0.32.0"
 }
 
 val libVersionName by extra(version as String)
@@ -20,8 +21,6 @@ val licenseUrl by extra("https://github.com/hotwired/hotwire-native-android/blob
 
 val developerId by extra("basecamp")
 val developerEmail by extra("androidteam@basecamp.com")
-
-val isSonatypeRelease by extra(project.hasProperty("sonatype"))
 
 android {
     namespace = "dev.hotwire.navigation"
@@ -66,12 +65,6 @@ android {
         named("test")  { java { srcDirs("src/test/kotlin") } }
         named("debug") { java { srcDirs("src/debug/kotlin") } }
     }
-
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-        }
-    }
 }
 
 dependencies {
@@ -113,92 +106,57 @@ java {
     }
 }
 
-tasks {
-    // Only sign Sonatype release artifacts
-    withType<Sign>().configureEach {
-        onlyIf { isSonatypeRelease }
-    }
-}
-
-// Sign Sonatype published release artifacts
-if (isSonatypeRelease) {
-    signing {
-        val keyId = System.getenv("GPG_KEY_ID")
-        val secretKey = System.getenv("GPG_SECRET_KEY")
-        val password = System.getenv("GPG_PASSWORD")
-
-        useInMemoryPgpKeys(keyId, secretKey, password)
-
-        setRequired({ gradle.taskGraph.hasTask("publish") })
-        sign(publishing.publications)
-    }
-}
-
 // Publish to GitHub Packages via:
-//   ./gradlew -Pversion=<version> clean build publish
+//   ./gradlew -Pversion=<version> clean build publishAllPublicationsToGithubPackagesRepository
+//   expected env variables: https://vanniktech.github.io/gradle-maven-publish-plugin/other/#github-packages-example
 //   https://github.com/orgs/hotwired/packages?repo_name=hotwire-native-android
 // Publish to Maven Central via:
-//   ./gradlew -Psonatype -Pversion=<version> clean build publish
-//   https://search.maven.org/artifact/dev.hotwire/navigation-fragments
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            groupId = publishedGroupId
-            artifactId = publishedArtifactId
-            version = libVersionName
+//   ./gradlew -Pversion=<version> clean build publishAndReleaseToMavenCentral --no-configuration-cache
+//   expected env variables: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#secrets
+//   https://central.sonatype.com/artifact/dev.hotwire/navigation-fragments
 
-            pom {
-                name.set(libraryName)
-                description.set(libraryDescription)
-                url.set(siteUrl)
+mavenPublishing {
+    coordinates(groupId = publishedGroupId, artifactId = publishedArtifactId, version = libVersionName)
 
-                licenses {
-                    license {
-                        name.set(licenseType)
-                        url.set(licenseUrl)
-                    }
-                }
-                developers {
-                    developer {
-                        id.set(developerId)
-                        name.set(developerId)
-                        email.set(developerEmail)
-                    }
-                }
-                scm {
-                    url.set(gitUrl)
-                }
-            }
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 
-            // Applies the component for the release build variant
-            afterEvaluate {
-                from(components["release"])
+    signAllPublications()
+
+    pom {
+        name.set(libraryName)
+        description.set(libraryDescription)
+        url.set(siteUrl)
+
+        licenses {
+            license {
+                name.set(licenseType)
+                url.set(licenseUrl)
             }
         }
+
+        developers {
+            developer {
+                id.set(developerId)
+                name.set(developerId)
+                email.set(developerEmail)
+            }
+        }
+
+        scm {
+            url.set(gitUrl)
+        }
     }
+}
+
+publishing {
     repositories {
-        if (isSonatypeRelease) {
-            maven {
-                // Temporarily switching to Sonatype OSSRH Staging API
-                // until the maven-publish plugin adds support for the new Central Portal
-                // see: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/
-                url = uri("https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/")
-
-                credentials {
-                    username = System.getenv("SONATYPE_USER")
-                    password = System.getenv("SONATYPE_PASSWORD")
-                }
-            }
-        } else {
-            maven {
-                name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/hotwired/hotwire-native-android")
-
-                credentials {
-                    username = System.getenv("GITHUB_ACTOR")
-                    password = System.getenv("GITHUB_TOKEN")
-                }
-            }
+        maven {
+            name = "githubPackages"
+            url = uri("https://maven.pkg.github.com/hotwired/hotwire-native-android")
+            // username and password (a personal Github access token) should be specified as
+            // `ORG_GRADLE_PROJECT_githubPackagesUsername` and `ORG_GRADLE_PROJECT_githubPackagesPassword`
+            // environment variables
+            credentials(PasswordCredentials::class)
         }
     }
 }


### PR DESCRIPTION
This PR migrates from Gradle maven-publish plugin to https://github.com/vanniktech/gradle-maven-publish-plugin which supports Maven Central.