### PR TITLE
Inform developers and users when the `WebView` component is outdated

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/errors/VisitError.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/errors/VisitError.kt
@@ -3,4 +3,11 @@ package dev.hotwire.core.turbo.errors
 /**
  * Represents all possible errors received when attempting to load a page.
  */
-sealed interface VisitError
+sealed interface VisitError {
+    fun description() = when (this) {
+        is HttpError -> reasonPhrase
+        is LoadError -> description
+        is WebError -> description
+        is WebSslError -> description
+    }
+}

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -5,7 +5,14 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.net.http.SslError
 import android.util.SparseArray
-import android.webkit.*
+import android.webkit.HttpAuthHandler
+import android.webkit.JavascriptInterface
+import android.webkit.RenderProcessGoneDetail
+import android.webkit.SslErrorHandler
+import android.webkit.WebChromeClient
+import android.webkit.WebResourceRequest
+import android.webkit.WebResourceResponse
+import android.webkit.WebView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.webkit.WebResourceErrorCompat
@@ -24,7 +31,10 @@ import dev.hotwire.core.turbo.errors.WebError
 import dev.hotwire.core.turbo.errors.WebSslError
 import dev.hotwire.core.turbo.http.HotwireHttpClient
 import dev.hotwire.core.turbo.http.HttpRepository
-import dev.hotwire.core.turbo.offline.*
+import dev.hotwire.core.turbo.offline.OfflineHttpRepository
+import dev.hotwire.core.turbo.offline.OfflinePreCacheRequest
+import dev.hotwire.core.turbo.offline.OfflineRequestHandler
+import dev.hotwire.core.turbo.offline.OfflineWebViewRequestInterceptor
 import dev.hotwire.core.turbo.util.isHttpGetRequest
 import dev.hotwire.core.turbo.util.runOnUiThread
 import dev.hotwire.core.turbo.util.toJson
@@ -33,6 +43,7 @@ import dev.hotwire.core.turbo.visit.VisitAction
 import dev.hotwire.core.turbo.visit.VisitOptions
 import dev.hotwire.core.turbo.webview.HotwireWebView
 import dev.hotwire.core.turbo.webview.WebViewInfo
+import dev.hotwire.core.turbo.webview.WebViewVersionCompatibility
 import kotlinx.coroutines.launch
 import java.util.Date
 
@@ -677,7 +688,7 @@ class Session(
             "version" to (webViewInfo.majorVersion ?: "")
         )
 
-        if ((webViewInfo.majorVersion ?: 0) < requiredVersion) {
+        if (WebViewVersionCompatibility.isOutdated(context, requiredVersion)) {
             logWarning(
                 "WebView outdated",
                 "The Chromium WebView installed on the device is outdated. Minimum version " +

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -668,7 +668,7 @@ class Session(
     @SuppressLint("SetJavaScriptEnabled")
     private fun initializeWebView() {
         val webViewInfo = Hotwire.webViewInfo(context)
-        val unsupportedVersion = WebViewInfo.UNSUPPORTED_WEBVIEW_VERSION
+        val requiredVersion = WebViewInfo.REQUIRED_WEBVIEW_VERSION
 
         logEvent(
             "WebView info",
@@ -677,11 +677,11 @@ class Session(
             "version" to (webViewInfo.majorVersion ?: "")
         )
 
-        if ((webViewInfo.majorVersion ?: 0) <= unsupportedVersion) {
+        if ((webViewInfo.majorVersion ?: 0) < requiredVersion) {
             logWarning(
                 "WebView outdated",
                 "The Chromium WebView installed on the device is outdated. Minimum version " +
-                    "${unsupportedVersion + 1} is required for modern browsers in Rails 8. " +
+                    "$requiredVersion is required for modern browsers in Rails 8. " +
                     "If you're using an emulator, ensure it has Play Services enabled and " +
                     "install the latest WebView version from the Play Store: " +
                     "${webViewInfo.playStoreWebViewAppUri}"

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewInfo.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewInfo.kt
@@ -21,7 +21,7 @@ class WebViewInfo internal constructor(context: Context) {
         /**
          * Rails 8 requires Chromium 120+ for "modern" browsers.
          */
-        const val UNSUPPORTED_WEBVIEW_VERSION = 119
+        const val REQUIRED_WEBVIEW_VERSION = 120
     }
 
     /**

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewInfo.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewInfo.kt
@@ -17,6 +17,13 @@ class WebViewInfo internal constructor(context: Context) {
         UNKNOWN
     }
 
+    companion object {
+        /**
+         * Rails 8 requires Chromium 120+ for "modern" browsers.
+         */
+        const val UNSUPPORTED_WEBVIEW_VERSION = 119
+    }
+
     /**
      * The system WebView's package info (corresponds to Chrome or Android System WebView).
      */

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewVersionCompatibility.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewVersionCompatibility.kt
@@ -2,6 +2,7 @@ package dev.hotwire.core.turbo.webview
 
 import android.app.Activity
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.text.Html
 import android.widget.Toast
@@ -13,20 +14,32 @@ import dev.hotwire.core.turbo.webview.WebViewInfo.WebViewType
 class WebViewVersionCompatibility {
     companion object {
         /**
-         * Display an alert dialog if the WebView component installed on the device is
-         * less than the `requiredVersion`. The user can tap "Update" to update the
-         * corresponding "Google Chrome" or "Android System WebView" app in the Play Store.
+         * Determines whether the WebView component version installed on the device is less
+         * than the `requiredVersion`.
+         *
+         * @return True if the WebView is outdated, otherwise false.
          */
-        fun displayUpdateDialogIfOutdated(activity: Activity, requiredVersion: Int) {
-            val versionInfo = Hotwire.webViewInfo(activity)
+        fun isOutdated(context: Context, requiredVersion: Int): Boolean {
+            val versionInfo = Hotwire.webViewInfo(context)
             val majorVersion = versionInfo.majorVersion
             val type = versionInfo.webViewType
 
-            if (type == WebViewType.UNKNOWN || majorVersion == null) {
-                return
-            }
+            return type != WebViewType.UNKNOWN &&
+                    majorVersion != null &&
+                    majorVersion < requiredVersion
+        }
 
-            if (majorVersion < requiredVersion) {
+        /**
+         * Display an alert dialog if the WebView component version installed on the device is
+         * less than the `requiredVersion`. The user can tap "Update" to update the
+         * corresponding "Google Chrome" or "Android System WebView" app in the Play Store.
+         *
+         * @return True if the WebView is outdated and the dialog is displayed, otherwise false.
+         */
+        fun displayUpdateDialogIfOutdated(activity: Activity, requiredVersion: Int): Boolean {
+            val versionInfo = Hotwire.webViewInfo(activity)
+
+            return if (isOutdated(activity, requiredVersion)) {
                 val descriptionResId = when (versionInfo.webViewType) {
                     WebViewType.CHROME -> R.string.webview_error_chrome_description
                     else -> R.string.webview_error_system_description
@@ -51,6 +64,10 @@ class WebViewVersionCompatibility {
                     }
                     .create()
                     .show()
+
+                true
+            } else {
+                false
             }
         }
     }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewVersionCompatibility.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/WebViewVersionCompatibility.kt
@@ -1,0 +1,57 @@
+package dev.hotwire.core.turbo.webview
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.text.Html
+import android.widget.Toast
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import dev.hotwire.core.R
+import dev.hotwire.core.config.Hotwire
+import dev.hotwire.core.turbo.webview.WebViewInfo.WebViewType
+
+class WebViewVersionCompatibility {
+    companion object {
+        /**
+         * Display an alert dialog if the WebView component installed on the device is
+         * less than the `requiredVersion`. The user can tap "Update" to update the
+         * corresponding "Google Chrome" or "Android System WebView" app in the Play Store.
+         */
+        fun displayUpdateDialogIfOutdated(activity: Activity, requiredVersion: Int) {
+            val versionInfo = Hotwire.webViewInfo(activity)
+            val majorVersion = versionInfo.majorVersion
+            val type = versionInfo.webViewType
+
+            if (type == WebViewType.UNKNOWN || majorVersion == null) {
+                return
+            }
+
+            if (majorVersion < requiredVersion) {
+                val descriptionResId = when (versionInfo.webViewType) {
+                    WebViewType.CHROME -> R.string.webview_error_chrome_description
+                    else -> R.string.webview_error_system_description
+                }
+
+                val formattedDescription = activity.getString(descriptionResId)
+                    .format(versionInfo.majorVersion, requiredVersion)
+
+                MaterialAlertDialogBuilder(activity)
+                    .setTitle(R.string.webview_error_title)
+                    .setMessage(Html.fromHtml(formattedDescription, 0))
+                    .setNegativeButton(R.string.hotwire_dialog_cancel) { dialog, _ ->
+                        dialog.dismiss()
+                    }
+                    .setPositiveButton(R.string.webview_error_update) { dialog, _ ->
+                        try {
+                            activity.startActivity(Intent(Intent.ACTION_VIEW, versionInfo.playStoreWebViewAppUri))
+                        } catch (_: ActivityNotFoundException) {
+                            Toast.makeText(activity, R.string.webview_error_store_unavailable, Toast.LENGTH_LONG).show()
+                        }
+                        dialog.dismiss()
+                    }
+                    .create()
+                    .show()
+            }
+        }
+    }
+}

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="hotwire_file_chooser_select_multiple">Select file(s)</string>
     <string name="hotwire_dialog_ok">OK</string>
     <string name="hotwire_dialog_cancel">Cancel</string>
-    <string name="webview_error_title">WebView Outdated</string>
+    <string name="webview_error_title">Update Required</string>
     <string name="webview_error_system_description">The <![CDATA[<b>Android System WebView v%1$d</b>]]> app on your device, provided by Google, is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]> and you can update in the Play Store.</string>
     <string name="webview_error_chrome_description">The <![CDATA[<b>Google Chrome v%1$d</b>]]> app on your device is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]> and you can update in the Play Store.</string>
     <string name="webview_error_store_unavailable">Play Store app is not available</string>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -5,8 +5,8 @@
     <string name="hotwire_dialog_ok">OK</string>
     <string name="hotwire_dialog_cancel">Cancel</string>
     <string name="webview_error_title">WebView Outdated</string>
-    <string name="webview_error_system_description">The <![CDATA[<b>Android System WebView v%1$d</b>]]> app on your device, provided by Google, is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]>, and you can update in the Play Store.</string>
-    <string name="webview_error_chrome_description">The <![CDATA[<b>Google Chrome v%1$d</b>]]> app on your device is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]>, and you can update in the Play Store.</string>
+    <string name="webview_error_system_description">The <![CDATA[<b>Android System WebView v%1$d</b>]]> app on your device, provided by Google, is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]> and you can update in the Play Store.</string>
+    <string name="webview_error_chrome_description">The <![CDATA[<b>Google Chrome v%1$d</b>]]> app on your device is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]> and you can update in the Play Store.</string>
     <string name="webview_error_store_unavailable">Play Store app is not available</string>
     <string name="webview_error_update">Update</string>
 </resources>

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -4,4 +4,9 @@
     <string name="hotwire_file_chooser_select_multiple">Select file(s)</string>
     <string name="hotwire_dialog_ok">OK</string>
     <string name="hotwire_dialog_cancel">Cancel</string>
+    <string name="webview_error_title">WebView Outdated</string>
+    <string name="webview_error_system_description">The <![CDATA[<b>Android System WebView v%1$d</b>]]> app on your device, provided by Google, is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]>, and you can update in the Play Store.</string>
+    <string name="webview_error_chrome_description">The <![CDATA[<b>Google Chrome v%1$d</b>]]> app on your device is outdated. To work properly, <![CDATA[<b>v%2$d is required</b>]]>, and you can update in the Play Store.</string>
+    <string name="webview_error_store_unavailable">Play Store app is not available</string>
+    <string name="webview_error_update">Update</string>
 </resources>

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -5,6 +5,8 @@ import android.view.View
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import com.google.android.material.bottomnavigation.BottomNavigationView
+import dev.hotwire.core.turbo.webview.WebViewInfo
+import dev.hotwire.core.turbo.webview.WebViewVersionCompatibility
 import dev.hotwire.demo.R
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.tabs.HotwireBottomNavigationController
@@ -23,6 +25,11 @@ class MainActivity : HotwireActivity() {
         findViewById<View>(R.id.root).applyDefaultImeWindowInsets()
 
         initializeBottomTabs()
+
+        WebViewVersionCompatibility.displayUpdateDialogIfOutdated(
+            activity = this,
+            requiredVersion = WebViewInfo.REQUIRED_WEBVIEW_VERSION
+        )
     }
 
     private fun initializeBottomTabs() {

--- a/demo/src/main/res/values/strings.xml
+++ b/demo/src/main/res/values/strings.xml
@@ -1,6 +1,4 @@
 <resources>
     <string name="app_name">Hotwire Native</string>
-    <string name="error_web_home">Error loading page</string>
-    <string name="error_web_home_description">The demo server may be starting up. Pull-to-refresh to try again in a minute.</string>
     <string name="menu_progress">Loading…</string>
 </resources>

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
@@ -7,11 +7,12 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
 import dev.hotwire.core.bridge.BridgeDelegate
-import dev.hotwire.core.turbo.errors.VisitError
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_FILES
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_GEOLOCATION_PERMISSION
+import dev.hotwire.core.turbo.errors.VisitError
 import dev.hotwire.core.turbo.webview.HotwireWebChromeClient
 import dev.hotwire.core.turbo.webview.HotwireWebView
 import dev.hotwire.navigation.R
@@ -128,7 +129,9 @@ open class HotwireWebBottomSheetFragment : HotwireBottomSheetFragment(), Hotwire
 
     @SuppressLint("InflateParams")
     override fun createErrorView(error: VisitError): View {
-        return layoutInflater.inflate(R.layout.hotwire_error, null)
+        return layoutInflater.inflate(R.layout.hotwire_error, null).apply {
+            findViewById<TextView>(R.id.hotwire_error_description).text = error.description()
+        }
     }
 
     override fun createWebChromeClient(): HotwireWebChromeClient {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
 import dev.hotwire.core.bridge.BridgeDelegate
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_FILES
@@ -146,7 +147,9 @@ open class HotwireWebFragment : HotwireFragment(), HotwireWebFragmentCallback {
 
     @SuppressLint("InflateParams")
     override fun createErrorView(error: VisitError): View {
-        return layoutInflater.inflate(R.layout.hotwire_error, null)
+        return layoutInflater.inflate(R.layout.hotwire_error, null).apply {
+            findViewById<TextView>(R.id.hotwire_error_description).text = error.description()
+        }
     }
 
     override fun createWebChromeClient(): HotwireWebChromeClient {

--- a/navigation-fragments/src/main/res/layout/hotwire_error.xml
+++ b/navigation-fragments/src/main/res/layout/hotwire_error.xml
@@ -8,7 +8,7 @@
 
     <com.google.android.material.textview.MaterialTextView
         style="@style/TextAppearance.MaterialComponents.Headline6"
-        android:id="@+id/hotwire_error_message"
+        android:id="@+id/hotwire_error_title"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="24dp"
@@ -18,5 +18,17 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_bias=".40" />
+
+    <com.google.android.material.textview.MaterialTextView
+        style="@style/TextAppearance.MaterialComponents.Caption"
+        android:id="@+id/hotwire_error_description"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="24dp"
+        android:layout_marginEnd="24dp"
+        android:layout_marginTop="8dp"
+        android:gravity="center_horizontal"
+        android:textSize="14sp"
+        app:layout_constraintTop_toBottomOf="@id/hotwire_error_title" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
This makes it possible to detect out-of-the-box when the system `WebView` component is outdated on a device. This can happen (to developers) when using an older Android Emulator without Play Services or (to users) when **Google Chrome** or **Android System WebView** automatic app updates have been disabled in the Play Store.

Rails 8 requires Chrome `120+` for its default configuration:
```ruby
allow_browser versions: :modern
```

Rails returns an HTTP `406` [when an unsupported Chromium WebView version tries to access the server](https://edgeapi.rubyonrails.org/classes/ActionController/AllowBrowser/ClassMethods.html). To make this easier to identify, the following improvements have been added:

### Log warning
A new debug log will be present when using a WebView version older than `WebViewInfo.REQUIRED_WEBVIEW_VERSION`, which is currently set to `120`. Example log warning:

```
D WebView info ...................... [session: navigation, package: com.google.android.webview, type: Android System WebView, version: 112]
W WebView outdated .................. [The Chromium WebView installed on the device is outdated. Minimum version 120 is required for modern browsers in Rails 8. If you're using an emulator, ensure it has Play Services enabled and install the latest WebView version from the Play Store: market://details?id=com.google.android.webview]
```

### Error screen with description
The default error view included in the framework now includes the specific `VisitError` description. For an HTTP `406`, this will read:

> **Error loading page**
>   Not Accessible

### Outdated WebView alert dialog
Developers can now use the new `WebViewVersionCompatibility` class to display an alert dialog in their app if the WebView version is outdated. Call it like:

```kotlin
WebViewVersionCompatibility.displayUpdateDialogIfOutdated(
    activity = this,
    requiredVersion = WebViewInfo.REQUIRED_WEBVIEW_VERSION // or whatever version you require
)
```

This dialog looks like the following screenshot and allows a user to update the WebView component through the Play Store:
![Screenshot_20250618-171617](https://github.com/user-attachments/assets/ba6a79f8-dfbd-47f5-ae44-a8e5b848512e)


