### PR TITLE
Allow the `HotwireBottomNavigationController` visibility to be programmatically controlled

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
@@ -25,9 +25,26 @@ import dev.hotwire.navigation.navigator.presentationContext
 class HotwireBottomNavigationController(
     val activity: HotwireActivity,
     val view: BottomNavigationView,
+    val initialVisibility: Visibility = Visibility.DEFAULT,
     val clearNavigationOnTabReselection: Boolean = true,
     val animateVisibilityChanges: Boolean = true
 ) : NavController.OnDestinationChangedListener {
+
+    /**
+     * The visibility mode for the `BottomNavigationView`.
+     */
+    enum class Visibility {
+        /**
+         * Visible by default, but hidden in modal screens and when the
+         * virtual keyboard is present on screen.
+         */
+        DEFAULT,
+
+        /**
+         * Always hidden.
+         */
+        HIDDEN
+    }
 
     private var keyboardVisible = false
         set(value) {
@@ -42,6 +59,15 @@ class HotwireBottomNavigationController(
         }
 
     private var listener: ((Int, HotwireBottomTab) -> Unit)? = null
+
+    /**
+     * Set the visibility of the `BottomNavigationView`.
+     */
+    var visibility = initialVisibility
+        set(value) {
+            field = value
+            updateVisibility()
+        }
 
     /**
      * The currently selected tab in the [BottomNavigationView].
@@ -182,7 +208,7 @@ class HotwireBottomNavigationController(
     }
 
     private fun updateVisibility() {
-        val visible = !keyboardVisible && !destinationIsModal
+        val visible = !keyboardVisible && !destinationIsModal && visibility != Visibility.HIDDEN
 
         if (visible != view.isVisible) {
             if (animateVisibilityChanges) {


### PR DESCRIPTION
This adds a new public `HotwireBottomNavigationController` API to set the visibility of the `BottomNavigationView` that it controls. There are currently two visibility modes that can be set through the `Visibility` enum:

```kotlin
/**
 * The visibility mode for the `BottomNavigationView`.
 */
enum class Visibility {
    /**
     * Visible by default, but hidden in modal screens and when the
     * virtual keyboard is present on screen.
     */
    DEFAULT,

    /**
     * Always hidden.
     */
    HIDDEN
}
```

To manually hide the `BottomNavigationView` in your `Activity` layout, you can call:

```kotlin
bottomNavigationController.visibility = Visibility.HIDDEN
```

Additionally, you can now set the `initialVisibility` through the `HotwireBottomNavigationController` constructor:

```kotlin
HotwireBottomNavigationController(
    activity = this, 
    view = bottomNavigationView, 
    initialVisibility = HotwireBottomNavigationController.Visibility.HIDDEN
)
```

This supersedes the approach in https://github.com/hotwired/hotwire-native-android/pull/139