### PR TITLE
Navigation: deeplink start location vulnerability fix

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -2,6 +2,8 @@ package dev.hotwire.navigation.navigator
 
 import android.os.Bundle
 import android.view.View
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.VisibleForTesting.Companion.PROTECTED
 import androidx.core.net.toUri
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -11,6 +13,9 @@ import androidx.navigation.fragment.findNavController
 import dev.hotwire.core.config.Hotwire
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.config.HotwireNavigation
+
+internal const val DEEPLINK_EXTRAS_KEY = "android-support-nav:controller:deepLinkExtras"
+internal const val LOCATION_KEY = "location"
 
 open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
     internal lateinit var activity: HotwireActivity
@@ -66,19 +71,17 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
         }
     }
 
-    private fun ensureDeeplinkStartLocationValid() {
-        val deepLinkExtrasKey = "android-support-nav:controller:deepLinkExtras"
-        val locationKey = "location"
-
-        val extrasBundle = activity.intent.extras?.getBundle(deepLinkExtrasKey) ?: return
-        val startLocation = extrasBundle.getString(locationKey) ?: return
+    @VisibleForTesting(otherwise = PROTECTED)
+    fun ensureDeeplinkStartLocationValid() {
+        val extrasBundle = activity.intent.extras?.getBundle(DEEPLINK_EXTRAS_KEY) ?: return
+        val startLocation = extrasBundle.getString(LOCATION_KEY) ?: return
 
         val deepLinkStartUri = startLocation.toUriOrNull()
         val configStartUri = configuration.startLocation.toUriOrNull()
 
         if (deepLinkStartUri?.host != configStartUri?.host) {
-            extrasBundle.putString(locationKey, configuration.startLocation)
-            activity.intent.putExtra(deepLinkExtrasKey, extrasBundle)
+            extrasBundle.putString(LOCATION_KEY, configuration.startLocation)
+            activity.intent.putExtra(DEEPLINK_EXTRAS_KEY, extrasBundle)
         }
     }
 

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorHostTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/navigator/NavigatorHostTest.kt
@@ -1,0 +1,61 @@
+package dev.hotwire.navigation.navigator
+
+import android.R.attr.host
+import android.content.Intent
+import android.os.Bundle
+import androidx.core.os.bundleOf
+import dev.hotwire.navigation.activities.HotwireActivity
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class NavigatorHostTest {
+
+    private lateinit var activity: TestActivity
+    private lateinit var host: NavigatorHost
+
+    @Before
+    fun setUp() {
+        host = NavigatorHost()
+    }
+
+    @Test
+    fun `reverts to config start location when deep link host differs`() {
+        val extras = bundleOf(LOCATION_KEY to "https://other.com/path")
+        val intent = Intent().apply { putExtra(DEEPLINK_EXTRAS_KEY, extras) }
+        activity = Robolectric.buildActivity(TestActivity::class.java, intent).get()
+
+        host.activity = activity
+        host.ensureDeeplinkStartLocationValid()
+
+        val resultBundle = activity.intent.getBundleExtra(DEEPLINK_EXTRAS_KEY)
+        assertThat(resultBundle?.getString(LOCATION_KEY)).isEqualTo("https://example.com/start")
+    }
+
+    @Test
+    fun `does not change start location when deep link host matches config`() {
+        val extras = bundleOf(LOCATION_KEY to "https://example.com/path")
+        val intent = Intent().apply { putExtra(DEEPLINK_EXTRAS_KEY, extras) }
+        activity = Robolectric.buildActivity(TestActivity::class.java, intent).get()
+
+        host.activity = activity
+        host.ensureDeeplinkStartLocationValid()
+
+        val resultBundle = activity.intent.getBundleExtra(DEEPLINK_EXTRAS_KEY)
+        assertThat(resultBundle?.getString(LOCATION_KEY)).isEqualTo("https://example.com/path")
+    }
+
+    private class TestActivity : HotwireActivity() {
+        private val navConfig = NavigatorConfiguration(
+            name = "test",
+            startLocation = "https://example.com/start",
+            navigatorHostId = 0
+        )
+
+        override fun navigatorConfigurations(): List<NavigatorConfiguration> = listOf(navConfig)
+    }
+}


### PR DESCRIPTION
This PR addresses a vulnerability introduced by the Jetpack Navigation library.

When the navigation graph is created, the Navigation library checks for deep link attributes inside of the Intent's extras. This can be potentially abused to navigate to a location inside of a HotwireWebFragment which is not app's owned domain.

Similar documented case: https://swarm.ptsecurity.com/android-jetpack-navigation-deep-links-handling-exploitation/

The fix is a simple check during navigation graph initialisation which ensures that the host of the deep link start location is the same as host of the NavHost start location set in the Hotwire Native config. If the hosts don't match, navigation to the deep link location is not allowed and is replaced with the start location from config.