### PR TITLE
Fix crash when accessing currentDestination

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -43,7 +43,7 @@ class Navigator(
      */
     val currentDestination: HotwireDestination?
         get() = currentDialogDestination as? HotwireDestination
-            ?: if (host.isAdded) {
+            ?: if (isReady()) {
                 host.childFragmentManager.primaryNavigationFragment as? HotwireDestination
             } else {
                 null


### PR DESCRIPTION
Sometimes, `currentDestination` is accessed outside of the lifecycle of the `NavigatorHost` fragment.

`Navigator.logEvent` tries to call `Navigator.getCurrentDestination`.
This in turn calls `NavigatorHost/Fragment.getChildFragmentManager`.

When the `Fragment` (`NavigatorHost`) is not attached, it throws an `IllegalStateException("Fragment ... has not been attached yet.")`.

I believe it should be enough to check that the Fragment is added and if it isn't, return `null` (which is a valid value for `Navigator.getCurrentDestination`).