### PR TITLE
Fix same page `restore` visits when returning to a web screen from a native screen

### DIFF
--- a/core/src/main/assets/js/turbo.js
+++ b/core/src/main/assets/js/turbo.js
@@ -57,6 +57,12 @@
       }
     }
 
+    cacheSnapshot() {
+      if (window.Turbo) {
+        Turbo.session.view.cacheSnapshot()
+      }
+    }
+
     // Current visit
 
     issueRequestForVisitWithIdentifier(identifier) {

--- a/core/src/main/assets/js/turbo.js
+++ b/core/src/main/assets/js/turbo.js
@@ -39,16 +39,7 @@
       let action = options.action
 
       if (window.Turbo) {
-        if (Turbo.navigator.location?.href === location && action === "restore") {
-          // A "restore" visit to the currently rendered location can occur when visiting
-          // a web -> native -> back to web screen. In this situation, the connect()
-          // callback (from Stimulus) in bridge component controllers will not be called,
-          // since they are already connected. We need to notify the web bridge library
-          // that a "restore" visit has occurred to manually trigger connect() and notify
-          // the native app so the native bridge component view state can be restored.
-          Turbo.navigator.startVisit(location, restorationIdentifier, options)
-          document.dispatchEvent(new Event("native:restore"))
-        } else if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
+        if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
           // Skip the same-page anchor scrolling behavior for visits initiated from the native
           // side. The page content may be stale and we want a fresh request from the network.
           Turbo.navigator.startVisit(location, restorationIdentifier, { "action": "replace" })
@@ -64,6 +55,16 @@
           Turbolinks.controller.startVisitToLocation(location, restorationIdentifier, options)
         }
       }
+    }
+
+    restoreCurrentVisit() {
+      // A synthetic "restore" visit to the currently rendered location can occur when
+      // visiting a web -> native -> back to web screen. In this situation, the connect()
+      // callback (from Stimulus) in bridge component controllers will not be called,
+      // since they are already connected. We need to notify the web bridge library
+      // that the webview has been reattached to manually trigger connect() and notify
+      // the native app so the native bridge component view state can be restored.
+      document.dispatchEvent(new Event("native:restore"))
     }
 
     cacheSnapshot() {

--- a/core/src/main/assets/js/turbo.js
+++ b/core/src/main/assets/js/turbo.js
@@ -39,7 +39,16 @@
       let action = options.action
 
       if (window.Turbo) {
-        if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
+        if (Turbo.navigator.location?.href === location && action === "restore") {
+          // A "restore" visit to the currently rendered location can occur when visiting
+          // a web -> native -> back to web screen. In this situation, the connect()
+          // callback (from Stimulus) in bridge component controllers will not be called,
+          // since they are already connected. We need to notify the web bridge library
+          // that a "restore" visit has occurred to manually trigger connect() and notify
+          // the native app so the native bridge component view state can be restored.
+          Turbo.navigator.startVisit(location, restorationIdentifier, options)
+          document.dispatchEvent(new Event("native:restore"))
+        } else if (Turbo.navigator.locationWithActionIsSamePage(new URL(location), action)) {
           // Skip the same-page anchor scrolling behavior for visits initiated from the native
           // side. The page content may be stale and we want a fresh request from the network.
           Turbo.navigator.startVisit(location, restorationIdentifier, { "action": "replace" })

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -159,29 +159,19 @@ class Session(
     }
 
     /**
-     * Synthetically restore the WebView's current visit without using a cached snapshot or a
-     * visit request. This is used when restoring a destination from the backstack,
-     * but the WebView's current location hasn't changed from the destination's location.
+     * Cache a snapshot of the current visit.
      */
-    fun restoreCurrentVisit(callback: SessionCallback): Boolean {
-        val visit = currentVisit ?: return false
-        val restorationIdentifier = restorationIdentifiers[visit.destinationIdentifier]
+    fun cacheSnapshot() {
+        if (!isReady) return
 
-        if (!isReady || restorationIdentifier == null) {
-            return false
+        currentVisit?.let {
+            logEvent("cacheSnapshot",
+                "location" to it.location,
+                "visitIdentifier" to it.identifier
+            )
+
+            webView.cacheSnapshot()
         }
-
-        logEvent("restoreCurrentVisit",
-            "location" to visit.location,
-            "visitIdentifier" to visit.identifier,
-            "restorationIdentifier" to restorationIdentifier
-        )
-
-        visit.callback = callback
-        visitRendered(visit.identifier)
-        visitCompleted(visit.identifier, restorationIdentifier)
-
-        return true
     }
 
     fun removeCallback(callback: SessionCallback) {

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -159,6 +159,34 @@ class Session(
     }
 
     /**
+     * Synthetically restore the WebView's current visit without using a cached snapshot or a
+     * visit request. This is used when restoring a destination from the backstack,
+     * but the WebView's current location hasn't changed from the destination's location.
+     */
+    fun restoreCurrentVisit(callback: SessionCallback): Boolean {
+        val visit = currentVisit ?: return false
+        val restorationIdentifier = restorationIdentifiers[visit.destinationIdentifier]
+
+        if (!isReady || restorationIdentifier == null) {
+            return false
+        }
+
+        logEvent("restoreCurrentVisit",
+            "location" to visit.location,
+            "visitIdentifier" to visit.identifier,
+            "restorationIdentifier" to restorationIdentifier
+        )
+
+        visit.callback = callback
+        visitRendered(visit.identifier)
+        visitCompleted(visit.identifier, restorationIdentifier)
+
+        webView.restoreCurrentVisit()
+
+        return true
+    }
+
+    /**
      * Cache a snapshot of the current visit.
      */
     fun cacheSnapshot() {

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
@@ -76,6 +76,10 @@ open class HotwireWebView @JvmOverloads constructor(
         runJavascript("turboNative.cacheSnapshot()")
     }
 
+    internal fun restoreCurrentVisit() {
+        runJavascript("turboNative.restoreCurrentVisit()")
+    }
+
     internal fun installBridge(onBridgeInstalled: () -> Unit) {
         val script = "window.turboNative == null"
         val bridge = context.contentFromAsset("js/turbo.js")

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/webview/HotwireWebView.kt
@@ -72,6 +72,10 @@ open class HotwireWebView @JvmOverloads constructor(
         runJavascript("turboNative.visitRenderedForColdBoot('$coldBootVisitIdentifier')")
     }
 
+    internal fun cacheSnapshot() {
+        runJavascript("turboNative.cacheSnapshot()")
+    }
+
     internal fun installBridge(onBridgeInstalled: () -> Unit) {
         val script = "window.turboNative == null"
         val bridge = context.contentFromAsset("js/turbo.js")

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
@@ -266,44 +266,6 @@ class SessionTest : BaseRepositoryTest() {
     }
 
     @Test
-    fun `restore current visit`() {
-        val visitIdentifier = "12345"
-        val restorationIdentifier = "67890"
-
-        session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.turboIsReady(true)
-        session.pageLoaded(restorationIdentifier)
-
-        assertThat(session.restoreCurrentVisit(callback)).isTrue()
-        verify(callback, times(2)).visitCompleted(false)
-    }
-
-    @Test
-    fun `restore current visit fails with no restoration identifier`() {
-        val visitIdentifier = "12345"
-
-        session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.turboIsReady(true)
-
-        assertThat(session.restoreCurrentVisit(callback)).isFalse()
-        verify(callback, times(1)).visitCompleted(false)
-    }
-
-    @Test
-    fun `restore current visit fails with session not ready`() {
-        val visitIdentifier = "12345"
-        val restorationIdentifier = "67890"
-
-        session.currentVisit = visit.copy(identifier = visitIdentifier)
-        session.pageLoaded(restorationIdentifier)
-        session.turboIsReady(false)
-
-        assertThat(session.restoreCurrentVisit(callback)).isFalse()
-        verify(callback, never()).visitCompleted(false)
-        verify(callback).requestFailedWithError(false, LoadError.NotReady)
-    }
-
-    @Test
     fun `webView is not null`() {
         assertThat(session.webView).isNotNull
     }

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
@@ -266,6 +266,40 @@ class SessionTest : BaseRepositoryTest() {
     }
 
     @Test
+    fun restoreCurrentVisit() {
+        val visitIdentifier = "12345"
+        val restorationIdentifier = "67890"
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.turboIsReady(true)
+        session.pageLoaded(restorationIdentifier)
+
+        assertThat(session.restoreCurrentVisit(callback)).isTrue()
+        verify(callback, times(2)).visitCompleted(false)
+        verify(webView, times(1)).restoreCurrentVisit()
+    }
+
+    @Test
+    fun restoreCurrentVisitFailsWithNoRestorationIdentifier() {
+        val visitIdentifier = "12345"
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.turboIsReady(true)
+        assertThat(session.restoreCurrentVisit(callback)).isFalse()
+        verify(callback, times(1)).visitCompleted(false)
+    }
+    @Test
+    fun restoreCurrentVisitFailsWithSessionNotReady() {
+        val visitIdentifier = "12345"
+        val restorationIdentifier = "67890"
+        session.currentVisit = visit.copy(identifier = visitIdentifier)
+        session.pageLoaded(restorationIdentifier)
+        session.turboIsReady(false)
+        assertThat(session.restoreCurrentVisit(callback)).isFalse()
+        verify(callback, never()).visitCompleted(false)
+        verify(callback).requestFailedWithError(false, LoadError.NotReady)
+    }
+
+
+    @Test
     fun `webView is not null`() {
         assertThat(session.webView).isNotNull
     }

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
@@ -266,9 +266,10 @@ class SessionTest : BaseRepositoryTest() {
     }
 
     @Test
-    fun restoreCurrentVisit() {
+    fun `restore current visit`() {
         val visitIdentifier = "12345"
         val restorationIdentifier = "67890"
+
         session.currentVisit = visit.copy(identifier = visitIdentifier)
         session.turboIsReady(true)
         session.pageLoaded(restorationIdentifier)
@@ -279,25 +280,29 @@ class SessionTest : BaseRepositoryTest() {
     }
 
     @Test
-    fun restoreCurrentVisitFailsWithNoRestorationIdentifier() {
+    fun `restore current visit fails with no restoration identifier`() {
         val visitIdentifier = "12345"
+
         session.currentVisit = visit.copy(identifier = visitIdentifier)
         session.turboIsReady(true)
+
         assertThat(session.restoreCurrentVisit(callback)).isFalse()
         verify(callback, times(1)).visitCompleted(false)
     }
+
     @Test
-    fun restoreCurrentVisitFailsWithSessionNotReady() {
+    fun `restore current visit fails with session not ready`() {
         val visitIdentifier = "12345"
         val restorationIdentifier = "67890"
+
         session.currentVisit = visit.copy(identifier = visitIdentifier)
         session.pageLoaded(restorationIdentifier)
         session.turboIsReady(false)
+
         assertThat(session.restoreCurrentVisit(callback)).isFalse()
         verify(callback, never()).visitCompleted(false)
         verify(callback).requestFailedWithError(false, LoadError.NotReady)
     }
-
 
     @Test
     fun `webView is not null`() {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
@@ -55,6 +55,7 @@ open class HotwireWebBottomSheetFragment : HotwireBottomSheetFragment(), Hotwire
 
     override fun onDestroyView() {
         super.onDestroyView()
+        webDelegate.onDestroyView()
         viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
@@ -55,6 +55,7 @@ open class HotwireWebFragment : HotwireFragment(), HotwireWebFragmentCallback {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        webDelegate.onDestroyView()
         viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -133,7 +133,7 @@ internal class HotwireWebFragmentDelegate(
 
     /**
      * Should be called by the implementing Fragment during
-     * [androidx.fragment.app.Fragment.onDestroy].
+     * [androidx.fragment.app.Fragment.onDestroyView].
      */
     fun onDestroyView() {
         // Manually cache a snapshot of the WebView when navigating from a

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -347,9 +347,15 @@ internal class HotwireWebFragmentDelegate(
 
             // Visit every time the WebView is reattached to the current Fragment.
             if (isWebViewAttachedToNewDestination) {
-                showProgressView(location)
-                visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
-                isInitialVisit = false
+                val currentSessionVisitRestored = !isInitialVisit &&
+                    session.currentVisit?.destinationIdentifier == identifier &&
+                    session.restoreCurrentVisit(this)
+
+                if (!currentSessionVisitRestored) {
+                    showProgressView(location)
+                    visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
+                    isInitialVisit = false
+                }
             }
         }
     }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -132,6 +132,19 @@ internal class HotwireWebFragmentDelegate(
     }
 
     /**
+     * Should be called by the implementing Fragment during
+     * [androidx.fragment.app.Fragment.onDestroy].
+     */
+    fun onDestroyView() {
+        // Manually cache a snapshot of the WebView when navigating from a
+        // web screen to a native screen. This allows a "restore" visit when
+        // revisiting this location again.
+        if (navigator.session.currentVisit?.location != navigator.location) {
+            navigator.session.cacheSnapshot()
+        }
+    }
+
+    /**
      * Should be called by the implementing Fragment during [HotwireDestination.refresh].
      */
     fun refresh(displayProgress: Boolean) {
@@ -334,15 +347,9 @@ internal class HotwireWebFragmentDelegate(
 
             // Visit every time the WebView is reattached to the current Fragment.
             if (isWebViewAttachedToNewDestination) {
-                val currentSessionVisitRestored = !isInitialVisit &&
-                    session.currentVisit?.destinationIdentifier == identifier &&
-                    session.restoreCurrentVisit(this)
-
-                if (!currentSessionVisitRestored) {
-                    showProgressView(location)
-                    visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
-                    isInitialVisit = false
-                }
+                showProgressView(location)
+                visit(location, restoreWithCachedSnapshot = !isInitialVisit, reload = false)
+                isInitialVisit = false
             }
         }
     }


### PR DESCRIPTION
This fixes: https://github.com/hotwired/hotwire-native-android/issues/136

Let's say you have 2 screens:

- Fragment `A` (web screen)
- Fragment `B` (native screen)

Previously, when you navigated from `A` -> `B` -> (back to) `A`, the library would perform a "synthetic" restore visit to the `A` screen, since the underlying session's `WebView` still resided at location `A` (`B` is native, so it didn't alter the `WebView` location).

This approach prevented `A` from recreating it's `View` state for bridge components on the screen. When `A` is no longer visible, it's `View` is destroyed by the system and only `B` is visible on screen. Additionally, the synthetic restore approach meant that we never cached snapshots when leaving `A` and visiting a native screen.

So, to fix this: I updated the functionality to:
- Cache snapshots whenever leaving a web screen and visiting a native screen

This wasn't sufficient, though, reattaching the `WebView` to the already currently rendered location does not trigger Stimulus to re-connect its controllers. This makes sense, since the page DOM hasn't actually changed. But, it's a problem in the native library since we need to rebuild the view state of the attached bridge components on the screen — and the way to do this is to see the `connect()` callback in bridge component controllers on the web.

To work around this, the native library now dispatches a `native:restore` event that the web bridge library can listen to in already connected bridge component controllers and manually call its `connect()` method. 

This is the corresponding PR to allow native apps to see bridge components reconnect after a synthetic `restore` visit:
https://github.com/hotwired/hotwire-native-bridge/pull/9
