### PR TITLE
Keep replace action

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -629,19 +629,14 @@ class Session(
             else -> ""
         }
 
-        val options = when (restorationIdentifier) {
-            "" -> visit.options.copy(action = VisitAction.ADVANCE)
-            else -> visit.options
-        }
-
         logEvent(
             "visitLocation",
             "location" to visit.location,
-            "options" to options,
+            "options" to visit.options,
             "restorationIdentifier" to restorationIdentifier
         )
 
-        webView.visitLocation(visit.location, options, restorationIdentifier)
+        webView.visitLocation(visit.location, visit.options, restorationIdentifier)
     }
 
     private fun visitLocationAsColdBoot(visit: Visit) {


### PR DESCRIPTION
When a restoration identifier is not available, the replace visits were converted to advance. This PR removes that behavior and retains the original action.

Resolves https://github.com/hotwired/hotwire-native-android/issues/164