### PR TITLE
Don't recreate the demo app MainActivity on orientation changes

### DIFF
--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
 
         <activity
             android:name="dev.hotwire.demo.main.MainActivity"
+            android:configChanges="orientation|screenSize"
             android:launchMode="singleInstance"
             android:theme="@style/MyTheme.DayNight"
             android:windowSoftInputMode="adjustResize"


### PR DESCRIPTION
Provide a good example default for applications. It's often unnecessary to recreate the main `Activity` on orientation changes. Activity recreation can cause lost state in a WebView form on orientation change.

Resolves https://github.com/hotwired/hotwire-native-android/issues/172