### PR TITLE
Allow BridgeComponents to receive the destination Fragment view lifecycle events

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentFragmentLifecycle.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeComponentFragmentLifecycle.kt
@@ -1,0 +1,6 @@
+package dev.hotwire.core.bridge
+
+interface BridgeComponentFragmentLifecycle {
+    fun onViewCreated()
+    fun onDestroyView()
+}

--- a/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeDelegate.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/bridge/BridgeDelegate.kt
@@ -14,10 +14,10 @@ class BridgeDelegate<D : BridgeDestination>(
 ) : DefaultLifecycleObserver {
     internal var bridge: Bridge? = null
     private var destinationIsActive: Boolean = false
-    private val initializedComponents = hashMapOf<String, BridgeComponent<D>>()
     private val resolvedLocation: String
         get() = bridge?.webView?.url ?: location
 
+    val initializedComponents = hashMapOf<String, BridgeComponent<D>>()
     val activeComponents: List<BridgeComponent<D>>
         get() = initializedComponents.map { it.value }.takeIf { destinationIsActive }.orEmpty()
 
@@ -101,8 +101,20 @@ class BridgeDelegate<D : BridgeDestination>(
         return activeComponents.filterIsInstance<C>().firstOrNull()
     }
 
-    inline fun <reified C> forEachComponent(action: (C) -> Unit) {
-        activeComponents.filterIsInstance<C>().forEach { action(it) }
+    inline fun <reified C> forEachInitializedComponent(action: (C) -> Unit) {
+        initializedComponents.forEach { (_, component) ->
+            if (component is C) {
+                action(component)
+            }
+        }
+    }
+
+    inline fun <reified C> forEachActiveComponent(action: (C) -> Unit) {
+        activeComponents.forEach { component ->
+            if (component is C) {
+                action(component)
+            }
+        }
     }
 
     private fun getOrCreateComponent(name: String): BridgeComponent<D>? {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebBottomSheetFragment.kt
@@ -9,6 +9,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
+import dev.hotwire.core.bridge.BridgeComponent
+import dev.hotwire.core.bridge.BridgeComponentFragmentLifecycle
 import dev.hotwire.core.bridge.BridgeDelegate
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_FILES
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_GEOLOCATION_PERMISSION
@@ -50,12 +52,18 @@ open class HotwireWebBottomSheetFragment : HotwireBottomSheetFragment(), Hotwire
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         webDelegate.onViewCreated()
+        bridgeDelegate.forEachInitializedComponent<BridgeComponentFragmentLifecycle> {
+            it.onViewCreated()
+        }
         viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         webDelegate.onDestroyView()
+        bridgeDelegate.forEachInitializedComponent<BridgeComponentFragmentLifecycle> {
+            it.onDestroyView()
+        }
         viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
     }
 
@@ -70,6 +78,14 @@ open class HotwireWebBottomSheetFragment : HotwireBottomSheetFragment(), Hotwire
         return when (requestCode) {
             HOTWIRE_REQUEST_CODE_GEOLOCATION_PERMISSION -> webDelegate.geoLocationPermissionResultLauncher
             else -> null
+        }
+    }
+
+    override fun onBridgeComponentInitialized(component: BridgeComponent<*>) {
+        super.onBridgeComponentInitialized(component)
+
+        if (component is BridgeComponentFragmentLifecycle) {
+            component.onViewCreated()
         }
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragment.kt
@@ -8,6 +8,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.activity.result.ActivityResultLauncher
+import dev.hotwire.core.bridge.BridgeComponent
+import dev.hotwire.core.bridge.BridgeComponentFragmentLifecycle
 import dev.hotwire.core.bridge.BridgeDelegate
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_FILES
 import dev.hotwire.core.files.util.HOTWIRE_REQUEST_CODE_GEOLOCATION_PERMISSION
@@ -50,12 +52,18 @@ open class HotwireWebFragment : HotwireFragment(), HotwireWebFragmentCallback {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         webDelegate.onViewCreated()
+        bridgeDelegate.forEachInitializedComponent<BridgeComponentFragmentLifecycle> {
+            it.onViewCreated()
+        }
         viewLifecycleOwner.lifecycle.addObserver(bridgeDelegate)
     }
 
     override fun onDestroyView() {
         super.onDestroyView()
         webDelegate.onDestroyView()
+        bridgeDelegate.forEachInitializedComponent<BridgeComponentFragmentLifecycle> {
+            it.onDestroyView()
+        }
         viewLifecycleOwner.lifecycle.removeObserver(bridgeDelegate)
     }
 
@@ -107,6 +115,14 @@ open class HotwireWebFragment : HotwireFragment(), HotwireWebFragmentCallback {
         return when (requestCode) {
             HOTWIRE_REQUEST_CODE_GEOLOCATION_PERMISSION -> webDelegate.geoLocationPermissionResultLauncher
             else -> null
+        }
+    }
+
+    override fun onBridgeComponentInitialized(component: BridgeComponent<*>) {
+        super.onBridgeComponentInitialized(component)
+
+        if (component is BridgeComponentFragmentLifecycle) {
+            component.onViewCreated()
         }
     }
 


### PR DESCRIPTION
Allow `BridgeComponent` instances to implement the `BridgeComponentFragmentLifecycle` interface to receive the destination `Fragment` `onViewCreated()` and `onDestroyView() callbacks`. This is useful to launch coroutines tied to the Fragment's `viewLifecycleOwner` so they can be reliably relaunched when the view is recreated.

Its use looks this:
```kotlin
internal class MyComponent(
    name: String,
    bridgeDelegate: BridgeDelegate<HotwireDestination>
) : BridgeComponent<HotwireDestination>(name, bridgeDelegate), BridgeComponentFragmentLifecycle {
    private val fragment = bridgeDelegate.destination.fragment

    override fun onViewCreated() {
        fragment.viewLifecycleOwner.lifecycleScope.launch {
            fragment.viewLifecycleOwner.lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                // run coroutine, such as collecting a Flow
            }
        }
    }

    override fun onDestroyView() {
        // Perform any cleanup
    }

    // remaining component code
}
```