### PR TITLE
Handle `null` `Intent` in `ensureDeeplinkStartLocationValid`

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -79,7 +79,7 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
      */
     @VisibleForTesting(otherwise = PROTECTED)
     fun ensureDeeplinkStartLocationValid() {
-        val extrasBundle = activity.intent.extras?.getBundle(DEEPLINK_EXTRAS_KEY) ?: return
+        val extrasBundle = activity.intent?.extras?.getBundle(DEEPLINK_EXTRAS_KEY) ?: return
         val startLocation = extrasBundle.getString(LOCATION_KEY) ?: return
 
         val deepLinkStartUri = startLocation.toUri()


### PR DESCRIPTION
Let me know if there's something else going on and this fix doesn't make sense. I don't have much experience with Android experience outside Hotwire Native apps.

Fixes the following error which was triggered by `navigator.reset()` in a `HotwireFragment`

```
java.lang.NullPointerException: Attempt to invoke virtual method 'android.os.Bundle android.content.Intent.getExtras()' on a null object reference
    at dev.hotwire.navigation.navigator.NavigatorHost.ensureDeeplinkStartLocationValid(NavigatorHost.kt:82)
```

Here's what my fragment looks like

```
@HotwireDestinationDeepLink("hotwire://fragment/refresh_app")
class RefreshAppFragment : HotwireFragment() {
    override fun onCreate(savedInstanceState: Bundle?) {
        super.onCreate(savedInstanceState)

        navigator.reset()
        (activity as? MainActivity)?.resetNavigators()
    }
}
```