### PR TITLE
Fix bottom sheet showing scroll position of triggering page

### DIFF
--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/fragments/HotwireWebFragmentDelegate.kt
@@ -6,6 +6,7 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts.RequestMultiplePermissions
 import androidx.activity.result.contract.ActivityResultContracts.RequestPermission
 import androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult
+import androidx.core.view.ScrollingView
 import androidx.lifecycle.Lifecycle.State.STARTED
 import androidx.lifecycle.findViewTreeLifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -231,6 +232,7 @@ internal class HotwireWebFragmentDelegate(
 
     override fun visitRendered() {
         callback.onVisitRendered(location)
+        resetWebViewScrollForScrollingContainer()
         navDestination.fragmentViewModel.setTitle(title())
         removeTransitionalViews()
     }
@@ -472,6 +474,19 @@ internal class HotwireWebFragmentDelegate(
 
     private fun pullToRefreshEnabled(enabled: Boolean) {
         hotwireView?.webViewRefresh?.isEnabled = enabled
+    }
+
+    /**
+     * When the WebView moves into a ScrollingView container (e.g., bottom
+     * sheet), its native scroll state carries over from the previous page
+     * and gets applied to the ScrollingView. Normally Turbo's JS would
+     * scroll to the top, but this has no effect on a WRAP_CONTENT WebView
+     * inside a ScrollingView. Reset it natively instead.
+     */
+    private fun resetWebViewScrollForScrollingContainer() {
+        if (webView.parent is ScrollingView) {
+            webView.scrollTo(0, 0)
+        }
     }
 
     private fun removeTransitionalViews() {


### PR DESCRIPTION
# Problem

When opening a bottom sheet from a scrolled page, the bottom sheet inherits the scroll position of the page that triggered it. The content appears offset — scrolled down by however far the user had scrolled on the underlying page.

[Screen_recording_20260312_172301.webm](https://github.com/user-attachments/assets/199bc527-20e2-49a9-8b88-8ef69df20de5)

The screen recording was made on v1.2.6 and the Demo app was using a version of hotwire-native-demo with the path config modified so that the modal pages are shown in a bottom sheet (`uri: "hotwire://fragment/web/modal/sheet"`)

I think this happens because the `WebView` carries its native `scrollY` when it moves between fragment containers. For normal page navigation this is not an issue: Turbo's JS `performScroll()` calls `window.scrollTo(0, 0)` which successfully resets the scroll. But in a bottom sheet, the `WebView` is sized with `WRAP_CONTENT` inside a `NestedScrollView` — in this layout the `WebView` is not internally scrollable from the JS perspective, so `window.scrollTo()` has no effect. The native `scrollY` persists and gets rendered as an offset inside the `NestedScrollView`.

# Proposed fix

Reset the `WebView`'s native scroll in visitRendered(), guarded by a check that the `WebView`'s parent is a `ScrollingView`. At this point in the lifecycle, Turbo has already called `changeHistory()` which updates `history.restorationIdentifier` to the new page's own ID — so the scroll event that fires from `scrollTo(0, 0)` updates the correct page's restoration data and does not corrupt the underlying page's saved scroll position. The reset also happens before `removeTransitionalViews()`, so the progress view is still visible and there is no visible flash.

Screen recording with fix:

[Screen_recording_20260312_173620.webm](https://github.com/user-attachments/assets/f2d1699a-b796-4191-a61d-37d963fe1cd4)



