### PR TITLE
Lazy load bottom tabs

### DIFF
--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -38,7 +38,7 @@ class MainActivity : HotwireActivity() {
         bottomNavigationController = HotwireBottomNavigationController(
             activity = this,
             view = bottomNavigationView,
-            deferInitialTabLoad = true
+            lazyLoadTabs = true
         )
         bottomNavigationController.load(mainTabs, viewModel.selectedTabIndex)
         bottomNavigationController.setOnTabSelectedListener { index, _ ->

--- a/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
+++ b/demo/src/main/kotlin/dev/hotwire/demo/main/MainActivity.kt
@@ -35,7 +35,11 @@ class MainActivity : HotwireActivity() {
     private fun initializeBottomTabs() {
         val bottomNavigationView = findViewById<BottomNavigationView>(R.id.bottom_nav)
 
-        bottomNavigationController = HotwireBottomNavigationController(this, bottomNavigationView)
+        bottomNavigationController = HotwireBottomNavigationController(
+            activity = this,
+            view = bottomNavigationView,
+            deferInitialTabLoad = true
+        )
         bottomNavigationController.load(mainTabs, viewModel.selectedTabIndex)
         bottomNavigationController.setOnTabSelectedListener { index, _ ->
             viewModel.selectedTabIndex = index

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
@@ -17,7 +17,6 @@ import dev.hotwire.navigation.observers.HotwireActivityObserver
 @Suppress("unused", "MemberVisibilityCanBePrivate")
 class HotwireActivityDelegate(val activity: HotwireActivity) {
     private val navigatorHosts = mutableMapOf<Int, NavigatorHost>()
-
     private val lazyNavigatorHostIds = mutableSetOf<Int>()
 
     private val onBackPressedCallback = object : OnBackPressedCallback(enabled = true) {
@@ -68,20 +67,16 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
 
         val navigatorHost = navigatorHosts[currentNavigatorHostId]
         if (navigatorHost != null) {
-            // Load the host's start destination on demand the first time it
-            // becomes the current navigator. This is a no-op if it's already
-            // been loaded.
             navigatorHost.initControllerGraphIfNeeded()
             updateOnBackPressedCallback(navigatorHost)
         }
     }
 
     /**
-     * Marks the given navigator hosts as lazy, meaning their start destination
+     * Sets the given navigator hosts as lazy, meaning their start destination
      * won't be loaded until the host first becomes the current navigator (e.g.
      * when its bottom tab is first selected). Any host not marked as lazy is
-     * loaded eagerly as soon as its view is created. Replaces any previously
-     * marked hosts.
+     * loaded eagerly as soon as its view is created.
      */
     internal fun setLazyNavigatorHosts(navigatorHostIds: Collection<Int>) {
         lazyNavigatorHostIds.clear()
@@ -101,7 +96,7 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
 
             // Load the host's start destination unless it's a lazy host that
             // isn't currently selected. Lazy hosts are loaded when they first
-            // become the current navigator (see setCurrentNavigator).
+            // become the current navigator.
             if (host.id !in lazyNavigatorHostIds || currentNavigatorHostId == host.id) {
                 host.initControllerGraphIfNeeded()
             }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
@@ -18,6 +18,16 @@ import dev.hotwire.navigation.observers.HotwireActivityObserver
 class HotwireActivityDelegate(val activity: HotwireActivity) {
     private val navigatorHosts = mutableMapOf<Int, NavigatorHost>()
 
+    /**
+     * The IDs of navigator hosts whose start destination should not be loaded
+     * until the host first becomes the current navigator (e.g. when its bottom
+     * tab is first selected). Hosts not in this set are loaded eagerly as soon
+     * as their view is created. Populated by
+     * [dev.hotwire.navigation.tabs.HotwireBottomNavigationController] when
+     * deferred tab loading is enabled.
+     */
+    internal val deferredNavigatorHostIds = mutableSetOf<Int>()
+
     private val onBackPressedCallback = object : OnBackPressedCallback(enabled = true) {
         override fun handleOnBackPressed() {
             currentNavigator?.pop()
@@ -66,6 +76,10 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
 
         val navigatorHost = navigatorHosts[currentNavigatorHostId]
         if (navigatorHost != null) {
+            // Load the host's start destination on demand the first time it
+            // becomes the current navigator. This is a no-op if it's already
+            // been loaded.
+            navigatorHost.initControllerGraphIfNeeded()
             updateOnBackPressedCallback(navigatorHost)
         }
     }
@@ -79,6 +93,13 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
 
             if (currentNavigatorHostId == host.id) {
                 updateOnBackPressedCallback(host)
+            }
+
+            // Load the host's start destination unless it's a deferred tab host
+            // that isn't currently selected. Deferred hosts are loaded when they
+            // first become the current navigator (see setCurrentNavigator).
+            if (host.id !in deferredNavigatorHostIds || currentNavigatorHostId == host.id) {
+                host.initControllerGraphIfNeeded()
             }
         }
     }
@@ -106,16 +127,22 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
 
     /**
      * Resets the sessions associated with all registered navigator hosts.
+     * Hosts that haven't loaded their start destination yet are skipped.
      */
     fun resetSessions() {
-        navigatorHosts.forEach { it.value.navigator.session.reset() }
+        navigatorHosts.values
+            .filter { it.isGraphInitialized }
+            .forEach { it.navigator.session.reset() }
     }
 
     /**
      * Resets all registered navigators via [Navigator.reset].
+     * Hosts that haven't loaded their start destination yet are skipped.
      */
     fun resetNavigators() {
-        navigatorHosts.forEach { it.value.navigator.reset() }
+        navigatorHosts.values
+            .filter { it.isGraphInitialized }
+            .forEach { it.navigator.reset() }
     }
 
     private fun listenToDestinationChanges(host: NavigatorHost) {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/activities/HotwireActivityDelegate.kt
@@ -18,15 +18,7 @@ import dev.hotwire.navigation.observers.HotwireActivityObserver
 class HotwireActivityDelegate(val activity: HotwireActivity) {
     private val navigatorHosts = mutableMapOf<Int, NavigatorHost>()
 
-    /**
-     * The IDs of navigator hosts whose start destination should not be loaded
-     * until the host first becomes the current navigator (e.g. when its bottom
-     * tab is first selected). Hosts not in this set are loaded eagerly as soon
-     * as their view is created. Populated by
-     * [dev.hotwire.navigation.tabs.HotwireBottomNavigationController] when
-     * deferred tab loading is enabled.
-     */
-    internal val deferredNavigatorHostIds = mutableSetOf<Int>()
+    private val lazyNavigatorHostIds = mutableSetOf<Int>()
 
     private val onBackPressedCallback = object : OnBackPressedCallback(enabled = true) {
         override fun handleOnBackPressed() {
@@ -84,6 +76,18 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
         }
     }
 
+    /**
+     * Marks the given navigator hosts as lazy, meaning their start destination
+     * won't be loaded until the host first becomes the current navigator (e.g.
+     * when its bottom tab is first selected). Any host not marked as lazy is
+     * loaded eagerly as soon as its view is created. Replaces any previously
+     * marked hosts.
+     */
+    internal fun setLazyNavigatorHosts(navigatorHostIds: Collection<Int>) {
+        lazyNavigatorHostIds.clear()
+        lazyNavigatorHostIds.addAll(navigatorHostIds)
+    }
+
     internal fun registerNavigatorHost(host: NavigatorHost) {
         logEvent("navigatorRegistered", listOf("navigator" to host.navigator.configuration.name))
 
@@ -95,10 +99,10 @@ class HotwireActivityDelegate(val activity: HotwireActivity) {
                 updateOnBackPressedCallback(host)
             }
 
-            // Load the host's start destination unless it's a deferred tab host
-            // that isn't currently selected. Deferred hosts are loaded when they
-            // first become the current navigator (see setCurrentNavigator).
-            if (host.id !in deferredNavigatorHostIds || currentNavigatorHostId == host.id) {
+            // Load the host's start destination unless it's a lazy host that
+            // isn't currently selected. Lazy hosts are loaded when they first
+            // become the current navigator (see setCurrentNavigator).
+            if (host.id !in lazyNavigatorHostIds || currentNavigatorHostId == host.id) {
                 host.initControllerGraphIfNeeded()
             }
         }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -211,7 +211,7 @@ class Navigator(
         navigateWhenReady {
             clearAll {
                 session.reset()
-                host.initControllerGraph()
+                host.resetControllerGraph()
 
                 if (host.view == null) {
                     onReset()

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -35,11 +35,6 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
         activity = requireActivity() as HotwireActivity
         navigator = Navigator(this, configuration, activity)
         childFragmentManager.addFragmentOnAttachListener(this)
-
-        // The graph (and therefore the start destination) is not built here.
-        // It's built when the host registers with the Activity delegate in
-        // onViewCreated, which allows the delegate to load the host eagerly
-        // (the default) or defer loading until its tab is first selected.
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -72,11 +67,16 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
      * host may need to become ready for navigation (e.g. when its tab is selected).
      */
     internal fun initControllerGraphIfNeeded() {
-        if (isGraphInitialized) return
+        if (!isGraphInitialized) {
+            initControllerGraph()
+        }
+    }
+
+    internal fun resetControllerGraph() {
         initControllerGraph()
     }
 
-    internal fun initControllerGraph() {
+    private fun initControllerGraph() {
         isGraphInitialized = true
         ensureDeeplinkStartLocationValid()
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -58,7 +58,10 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
      * has not been created yet.
      */
     fun isReady(): Boolean {
-        return isAdded && !isDetached && childFragmentManager.primaryNavigationFragment != null
+        return isGraphInitialized
+                && isAdded
+                && !isDetached
+                && childFragmentManager.primaryNavigationFragment != null
     }
 
     /**

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/NavigatorHost.kt
@@ -22,6 +22,13 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
     lateinit var navigator: Navigator
         private set
 
+    /**
+     * Whether the navigation graph has been built and the start destination
+     * loaded. See [initControllerGraphIfNeeded].
+     */
+    internal var isGraphInitialized = false
+        private set
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -29,7 +36,10 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
         navigator = Navigator(this, configuration, activity)
         childFragmentManager.addFragmentOnAttachListener(this)
 
-        initControllerGraph()
+        // The graph (and therefore the start destination) is not built here.
+        // It's built when the host registers with the Activity delegate in
+        // onViewCreated, which allows the delegate to load the host eagerly
+        // (the default) or defer loading until its tab is first selected.
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -56,7 +66,18 @@ open class NavigatorHost : NavHostFragment(), FragmentOnAttachListener {
         return isAdded && !isDetached && childFragmentManager.primaryNavigationFragment != null
     }
 
+    /**
+     * Builds the navigation graph and loads the start destination if it hasn't
+     * been built already. This is idempotent, so it's safe to call whenever the
+     * host may need to become ready for navigation (e.g. when its tab is selected).
+     */
+    internal fun initControllerGraphIfNeeded() {
+        if (isGraphInitialized) return
+        initControllerGraph()
+    }
+
     internal fun initControllerGraph() {
+        isGraphInitialized = true
         ensureDeeplinkStartLocationValid()
 
         navController.apply {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
@@ -106,14 +106,11 @@ class HotwireBottomNavigationController(
 
         this.tabs = tabs
 
-        // Register which hosts should defer loading before their views are
-        // created and registered with the delegate. The initially selected tab
-        // is still loaded immediately when it becomes the current navigator.
-        activity.delegate.deferredNavigatorHostIds.apply {
-            clear()
-            if (lazyLoadTabs) {
-                addAll(tabs.map { it.configuration.navigatorHostId })
-            }
+        // Mark the tab hosts as lazy before their views are created and
+        // registered with the delegate. The initially selected tab is still
+        // loaded immediately when it becomes the current navigator.
+        if (lazyLoadTabs) {
+            activity.delegate.setLazyNavigatorHosts(tabs.map { it.configuration.navigatorHostId })
         }
 
         val initialIndex = selectedTabIndex.coerceIn(0, tabs.lastIndex)

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
@@ -22,6 +22,15 @@ import dev.hotwire.navigation.navigator.presentationContext
  * A [BottomNavigationView] controller that manages multiple [HotwireBottomTab]s, each associated
  * with its own [NavigatorHost] instance in the Activity layout.
  *
+ * @param activity The [HotwireActivity] that hosts the [BottomNavigationView] and its tabs.
+ * @param view The [BottomNavigationView] in your layout to manage.
+ * @param initialVisibility The initial [Visibility] mode for the [BottomNavigationView]. Defaults
+ *  to [Visibility.DEFAULT].
+ * @param clearNavigationOnTabReselection When `true` (the default), reselecting the already-active
+ *  tab clears its navigation backstack to the start destination. When `false`, reselecting a tab
+ *  has no effect.
+ * @param animateVisibilityChanges When `true` (the default), the [BottomNavigationView] animates in
+ *  and out when its visibility changes. When `false`, visibility changes are applied instantly.
  * @param lazyLoadTabs When `false` (the default), every tab's [NavigatorHost] loads its
  *  start location as soon as its view is created, so all tabs load up front. When `true`, a tab's
  *  start location is not loaded until that tab is first selected, avoiding loading (and creating a

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
@@ -22,7 +22,7 @@ import dev.hotwire.navigation.navigator.presentationContext
  * A [BottomNavigationView] controller that manages multiple [HotwireBottomTab]s, each associated
  * with its own [NavigatorHost] instance in the Activity layout.
  *
- * @param deferInitialTabLoad When `false` (the default), every tab's [NavigatorHost] loads its
+ * @param lazyLoadTabs When `false` (the default), every tab's [NavigatorHost] loads its
  *  start location as soon as its view is created, so all tabs load up front. When `true`, a tab's
  *  start location is not loaded until that tab is first selected, avoiding loading (and creating a
  *  web view visit for) every tab at once. The initially selected tab still loads immediately.
@@ -33,7 +33,7 @@ class HotwireBottomNavigationController(
     val initialVisibility: Visibility = Visibility.DEFAULT,
     val clearNavigationOnTabReselection: Boolean = true,
     val animateVisibilityChanges: Boolean = true,
-    val deferInitialTabLoad: Boolean = false
+    val lazyLoadTabs: Boolean = false
 ) : NavController.OnDestinationChangedListener {
 
     /**
@@ -111,7 +111,7 @@ class HotwireBottomNavigationController(
         // is still loaded immediately when it becomes the current navigator.
         activity.delegate.deferredNavigatorHostIds.apply {
             clear()
-            if (deferInitialTabLoad) {
+            if (lazyLoadTabs) {
                 addAll(tabs.map { it.configuration.navigatorHostId })
             }
         }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/tabs/HotwireBottomNavigationController.kt
@@ -21,13 +21,19 @@ import dev.hotwire.navigation.navigator.presentationContext
 /**
  * A [BottomNavigationView] controller that manages multiple [HotwireBottomTab]s, each associated
  * with its own [NavigatorHost] instance in the Activity layout.
+ *
+ * @param deferInitialTabLoad When `false` (the default), every tab's [NavigatorHost] loads its
+ *  start location as soon as its view is created, so all tabs load up front. When `true`, a tab's
+ *  start location is not loaded until that tab is first selected, avoiding loading (and creating a
+ *  web view visit for) every tab at once. The initially selected tab still loads immediately.
  */
 class HotwireBottomNavigationController(
     val activity: HotwireActivity,
     val view: BottomNavigationView,
     val initialVisibility: Visibility = Visibility.DEFAULT,
     val clearNavigationOnTabReselection: Boolean = true,
-    val animateVisibilityChanges: Boolean = true
+    val animateVisibilityChanges: Boolean = true,
+    val deferInitialTabLoad: Boolean = false
 ) : NavController.OnDestinationChangedListener {
 
     /**
@@ -99,6 +105,16 @@ class HotwireBottomNavigationController(
         removeDestinationChangedListener()
 
         this.tabs = tabs
+
+        // Register which hosts should defer loading before their views are
+        // created and registered with the delegate. The initially selected tab
+        // is still loaded immediately when it becomes the current navigator.
+        activity.delegate.deferredNavigatorHostIds.apply {
+            clear()
+            if (deferInitialTabLoad) {
+                addAll(tabs.map { it.configuration.navigatorHostId })
+            }
+        }
 
         val initialIndex = selectedTabIndex.coerceIn(0, tabs.lastIndex)
         val initialTab = tabs[initialIndex]


### PR DESCRIPTION
### Summary

By default, an app with bottom tabs loads every tab's initial screen at startup — each tab's navigator immediately visits its start location, even for tabs the user may never open. For apps with several tabs, this means a burst of web view visits up front.

This PR adds an opt-in that defers each tab's initial load until the tab is first selected. The initially selected tab still loads right away; the others load the first time you tap into them, and stay loaded afterward. This spreads out the work and avoids paying for tabs that are never visited.

Eager loading remains the default, so existing apps are unaffected unless they opt in.

### Public API changes

**`HotwireBottomNavigationController`** gains a new optional constructor parameter, `lazyLoadTabs: Boolean = false`. Set it to `true` to enable deferred tab loading:

  ```kotlin
  HotwireBottomNavigationController(
      activity = this,
      view = bottomNavigationView,
      lazyLoadTabs = true
  )
  ```

No other public APIs change, and the default (`false`) preserves the current behavior.

### Notes

- Deferral is scoped to bottom tab hosts only. Nested and standalone navigator hosts continue to load eagerly.
- The demo app enables `lazyLoadTabs` to exercise the new behavior.