### PR TITLE
Pass the full `VisitProposal` to registered `RouteDecisionHandler` instances

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/visit/VisitProposal.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/visit/VisitProposal.kt
@@ -1,0 +1,11 @@
+package dev.hotwire.core.turbo.visit
+
+import android.os.Bundle
+import dev.hotwire.core.turbo.config.PathConfigurationProperties
+
+data class VisitProposal(
+    val location: String,
+    val options: VisitOptions,
+    val properties: PathConfigurationProperties,
+    val bundle: Bundle?
+)

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/destinations/HotwireDestination.kt
@@ -11,6 +11,7 @@ import dev.hotwire.core.turbo.config.PathConfigurationProperties
 import dev.hotwire.core.turbo.config.context
 import dev.hotwire.core.turbo.nav.PresentationContext
 import dev.hotwire.core.turbo.visit.VisitAction
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.fragments.HotwireFragmentDelegate
 import dev.hotwire.navigation.fragments.HotwireFragmentViewModel
 import dev.hotwire.navigation.navigator.Navigator
@@ -115,7 +116,7 @@ interface HotwireDestination : BridgeDestination {
      * Return `null` to use the global [Router.RouteDecisionHandler] instances to determine
      * routing logic.
      */
-    fun customRouteDecision(newLocation: String): Router.Decision? {
+    fun customRouteDecision(proposal: VisitProposal): Router.Decision? {
         return null
     }
 

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -13,6 +13,7 @@ import dev.hotwire.core.turbo.nav.PresentationContext
 import dev.hotwire.core.turbo.session.Session
 import dev.hotwire.core.turbo.visit.VisitAction
 import dev.hotwire.core.turbo.visit.VisitOptions
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.config.HotwireNavigation
 import dev.hotwire.navigation.destinations.HotwireDestination
@@ -138,7 +139,7 @@ class Navigator(
         extras: FragmentNavigator.Extras? = null
     ) {
 
-        if (getRouteDecision(location) == Router.Decision.CANCEL) {
+        if (getRouteDecision(location, options, bundle) == Router.Decision.CANCEL) {
             return
         }
 
@@ -423,11 +424,22 @@ class Navigator(
         return customNavigator?.navController ?: navController
     }
 
-    private fun getRouteDecision(location: String): Router.Decision {
+    private fun getRouteDecision(
+        location: String,
+        options: VisitOptions,
+        bundle: Bundle?
+    ): Router.Decision {
         val customDecision = currentDestination?.customRouteDecision(location)
 
-        val decision = customDecision ?: HotwireNavigation.router.decideRoute(
+        val proposal = VisitProposal(
             location = location,
+            options = options,
+            properties = Hotwire.config.pathConfiguration.properties(location),
+            bundle = bundle
+        )
+
+        val decision = customDecision ?: HotwireNavigation.router.decideRoute(
+            proposal = proposal,
             configuration = configuration,
             activity = activity
         )

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/navigator/Navigator.kt
@@ -429,14 +429,14 @@ class Navigator(
         options: VisitOptions,
         bundle: Bundle?
     ): Router.Decision {
-        val customDecision = currentDestination?.customRouteDecision(location)
-
         val proposal = VisitProposal(
             location = location,
             options = options,
             properties = Hotwire.config.pathConfiguration.properties(location),
             bundle = bundle
         )
+
+        val customDecision = currentDestination?.customRouteDecision(proposal)
 
         val decision = customDecision ?: HotwireNavigation.router.decideRoute(
             proposal = proposal,

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandler.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.navigation.routing
 
 import androidx.core.net.toUri
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 
@@ -11,14 +12,14 @@ class AppNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "app-navigation"
 
     override fun matches(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration
     ): Boolean {
-        return configuration.startLocation.toUri().host == location.toUri().host
+        return configuration.startLocation.toUri().host == proposal.location.toUri().host
     }
 
     override fun handle(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
     ): Router.Decision {

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandler.kt
@@ -5,6 +5,7 @@ import androidx.browser.customtabs.CustomTabColorSchemeParams
 import androidx.browser.customtabs.CustomTabsIntent
 import androidx.core.net.toUri
 import com.google.android.material.R
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.logging.logError
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
@@ -21,17 +22,17 @@ class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "browser-tab"
 
     override fun matches(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration
     ): Boolean {
-        val locationUri = location.toUri()
+        val locationUri = proposal.location.toUri()
 
         return configuration.startLocation.toUri().host != locationUri.host &&
                 (locationUri.scheme?.lowercase() == "https" || locationUri.scheme?.lowercase() == "http")
     }
 
     override fun handle(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
     ): Router.Decision {
@@ -48,7 +49,7 @@ class BrowserTabRouteDecisionHandler : Router.RouteDecisionHandler {
                 .setUrlBarHidingEnabled(false)
                 .setDefaultColorSchemeParams(colorParams)
                 .build()
-                .launchUrl(activity, location.toUri())
+                .launchUrl(activity, proposal.location.toUri())
         } catch (e: ActivityNotFoundException) {
             logError("BrowserTabRouteDecisionHandler", e)
         }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/Router.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/Router.kt
@@ -1,5 +1,6 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.logging.logDebug
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
@@ -21,12 +22,12 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
         val name: String
 
         /**
-         * Determines whether the location matches this decision handler. Use
-         * your own custom rules based on the location's domain, protocol,
-         * path, or any other factors.
+         * Determines whether the visit proposal matches this decision handler. Use
+         * your own custom rules based on the proposal's location domain, protocol,
+         * path, options, path configuration properties, or any other factors.
          */
         fun matches(
-            location: String,
+            proposal: VisitProposal,
             configuration: NavigatorConfiguration
         ): Boolean
 
@@ -36,7 +37,7 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
          * [Decision.CANCEL].
          */
         fun handle(
-            location: String,
+            proposal: VisitProposal,
             configuration: NavigatorConfiguration,
             activity: HotwireActivity
         ): Decision
@@ -55,22 +56,22 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
     }
 
     internal fun decideRoute(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
     ): Decision {
         decisionHandlers.forEach { handler ->
-            if (handler.matches(location, configuration)) {
+            if (handler.matches(proposal, configuration)) {
                 logDebug("handlerMatch", listOf(
                     "handler" to handler.name,
-                    "location" to location
+                    "location" to proposal.location
                 ))
 
-                return handler.handle(location, configuration, activity)
+                return handler.handle(proposal, configuration, activity)
             }
         }
 
-        logDebug("noHandlerForLocation", location)
+        logDebug("noHandlerForLocation", proposal.location)
         return Decision.CANCEL
     }
 }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/Router.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/Router.kt
@@ -64,14 +64,14 @@ class Router(private val decisionHandlers: List<RouteDecisionHandler>) {
             if (handler.matches(proposal, configuration)) {
                 logDebug("handlerMatch", listOf(
                     "handler" to handler.name,
-                    "location" to proposal.location
+                    "proposal" to proposal
                 ))
 
                 return handler.handle(proposal, configuration, activity)
             }
         }
 
-        logDebug("noHandlerForLocation", proposal.location)
+        logDebug("noHandlerForProposal", proposal.toString())
         return Decision.CANCEL
     }
 }

--- a/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandler.kt
+++ b/navigation-fragments/src/main/java/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandler.kt
@@ -3,6 +3,7 @@ package dev.hotwire.navigation.routing
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import androidx.core.net.toUri
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.logging.logError
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
@@ -14,18 +15,18 @@ class SystemNavigationRouteDecisionHandler : Router.RouteDecisionHandler {
     override val name = "system-navigation"
 
     override fun matches(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration
     ): Boolean {
-        return configuration.startLocation.toUri().host != location.toUri().host
+        return configuration.startLocation.toUri().host != proposal.location.toUri().host
     }
 
     override fun handle(
-        location: String,
+        proposal: VisitProposal,
         configuration: NavigatorConfiguration,
         activity: HotwireActivity
     ): Router.Decision {
-        val intent = Intent(Intent.ACTION_VIEW, location.toUri())
+        val intent = Intent(Intent.ACTION_VIEW, proposal.location.toUri())
 
         try {
             activity.startActivity(intent)

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/AppNavigationRouteDecisionHandlerTest.kt
@@ -1,5 +1,8 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.core.turbo.config.PathConfigurationProperties
+import dev.hotwire.core.turbo.visit.VisitOptions
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 import org.junit.Assert.assertEquals
@@ -29,27 +32,34 @@ class AppNavigationRouteDecisionHandlerTest {
 
     @Test
     fun `matching result navigates`() {
-        val decision = route.handle(config.startLocation, config, activity)
+        val decision = route.handle(proposal(config.startLocation), config, activity)
         assertEquals(Router.Decision.NAVIGATE, decision)
     }
 
     @Test
     fun `url on app domain matches`() {
         val url = "https://my.app.com/page"
-        assertTrue(route.matches(url, config))
+        assertTrue(route.matches(proposal(url), config))
     }
 
     @Test
     fun `url without subdomain does not match`() {
         val url = "https://app.com/page"
-        assertFalse(route.matches(url, config))
+        assertFalse(route.matches(proposal(url), config))
     }
 
     @Test
     fun `masqueraded url does not match`() {
         val url = "https://app.my.com@fake.domain"
-        assertFalse(route.matches(url, config))
+        assertFalse(route.matches(proposal(url), config))
     }
+
+    private fun proposal(location: String) = VisitProposal(
+        location = location,
+        options = VisitOptions(),
+        properties = PathConfigurationProperties(),
+        bundle = null
+    )
 
     private class TestActivity : HotwireActivity() {
         override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/BrowserTabRouteDecisionHandlerTest.kt
@@ -1,5 +1,8 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.core.turbo.config.PathConfigurationProperties
+import dev.hotwire.core.turbo.visit.VisitOptions
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 import org.junit.Assert.assertEquals
@@ -29,33 +32,40 @@ class BrowserTabRouteDecisionHandlerTest {
 
     @Test
     fun `matching result stops navigation`() {
-        val decision = route.handle("https://external.com/page", config, activity)
+        val decision = route.handle(proposal("https://external.com/page"), config, activity)
         assertEquals(Router.Decision.CANCEL, decision)
     }
 
     @Test
     fun `url on external domain matches`() {
         val url = "https://external.com/page"
-        assertTrue(route.matches(url, config))
+        assertTrue(route.matches(proposal(url), config))
     }
 
     @Test
     fun `url without subdomain matches`() {
         val url = "https://app.com/page"
-        assertTrue(route.matches(url, config))
+        assertTrue(route.matches(proposal(url), config))
     }
 
     @Test
     fun `url on app domain does not match`() {
         val url = "https://my.app.com/page"
-        assertFalse(route.matches(url, config))
+        assertFalse(route.matches(proposal(url), config))
     }
 
     @Test
     fun `non-http scheme does not match`() {
         val url = "sms:555-555-5555"
-        assertFalse(route.matches(url, config))
+        assertFalse(route.matches(proposal(url), config))
     }
+
+    private fun proposal(location: String) = VisitProposal(
+        location = location,
+        options = VisitOptions(),
+        properties = PathConfigurationProperties(),
+        bundle = null
+    )
 
     private class TestActivity : HotwireActivity() {
         override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()

--- a/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandlerTest.kt
+++ b/navigation-fragments/src/test/kotlin/dev/hotwire/navigation/routing/SystemNavigationRouteDecisionHandlerTest.kt
@@ -1,5 +1,8 @@
 package dev.hotwire.navigation.routing
 
+import dev.hotwire.core.turbo.config.PathConfigurationProperties
+import dev.hotwire.core.turbo.visit.VisitOptions
+import dev.hotwire.core.turbo.visit.VisitProposal
 import dev.hotwire.navigation.activities.HotwireActivity
 import dev.hotwire.navigation.navigator.NavigatorConfiguration
 import org.junit.Assert.assertEquals
@@ -29,33 +32,40 @@ class SystemNavigationRouteDecisionHandlerTest {
 
     @Test
     fun `matching result stops navigation`() {
-        val decision = route.handle("https://external.com/page", config, activity)
+        val decision = route.handle(proposal("https://external.com/page"), config, activity)
         assertEquals(Router.Decision.CANCEL, decision)
     }
 
     @Test
     fun `url on external domain matches`() {
         val url = "https://external.com/page"
-        assertTrue(route.matches(url, config))
+        assertTrue(route.matches(proposal(url), config))
     }
 
     @Test
     fun `url without subdomain matches`() {
         val url = "https://app.com/page"
-        assertTrue(route.matches(url, config))
+        assertTrue(route.matches(proposal(url), config))
     }
 
     @Test
     fun `url on app domain does not match`() {
         val url = "https://my.app.com/page"
-        assertFalse(route.matches(url, config))
+        assertFalse(route.matches(proposal(url), config))
     }
 
     @Test
     fun `non-http scheme matches`() {
         val url = "sms:555-555-5555"
-        assertTrue(route.matches(url, config))
+        assertTrue(route.matches(proposal(url), config))
     }
+
+    private fun proposal(location: String) = VisitProposal(
+        location = location,
+        options = VisitOptions(),
+        properties = PathConfigurationProperties(),
+        bundle = null
+    )
 
     private class TestActivity : HotwireActivity() {
         override fun navigatorConfigurations() = emptyList<NavigatorConfiguration>()


### PR DESCRIPTION
## Pass `VisitProposal` to route decision handlers

Route decision handlers previously only received the destination `location` string, which limited the routing logic apps could implement. This change passes the full `VisitProposal` instead — giving apps access to the location, visit options, path configuration properties, and bundle so they can build more comprehensive `RouteDecisionHandler`s.

### ⚠️ Breaking API changes

- `RouteDecisionHandler.matches(location: String, ...)` → `matches(proposal: VisitProposal, ...)`
- `RouteDecisionHandler.handle(location: String, ...)` → `handle(proposal: VisitProposal, ...)`
- `HotwireDestination.customRouteDecision(newLocation: String)` → `customRouteDecision(proposal: VisitProposal)`

Apps with custom `RouteDecisionHandler` implementations or `customRouteDecision` overrides will need to update their signatures. The location is still available via `proposal.location`.

### Notes

The built-in handlers (app navigation, system navigation, browser tab) and their tests have been updated accordingly.