### PR TITLE
Fix crash on non-HTTP scheme links

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationData.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/config/PathConfigurationData.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.core.turbo.config
 
 import com.google.gson.annotations.SerializedName
+import java.net.MalformedURLException
 import java.net.URL
 
 @ConsistentCopyVisibility
@@ -36,7 +37,11 @@ data class PathConfigurationData internal constructor(
     }
 
     private fun path(location: String): String {
-        val url = URL(location)
+        val url = try {
+            URL(location)
+        } catch (e: MalformedURLException) {
+            return ""
+        }
 
         return if (url.query == null) {
             url.path

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/config/PathConfigurationTest.kt
@@ -202,6 +202,14 @@ class PathConfigurationTest : BaseRepositoryTest() {
     }
 
     @Test
+    fun unknownSchemeLocationDoesNotThrow() {
+        assertThat(pathConfiguration.properties("mailto:test@example.com")).isNotNull
+        assertThat(pathConfiguration.properties("tel:+15551234567")).isNotNull
+        assertThat(pathConfiguration.properties("sms:+15551234567")).isNotNull
+        assertThat(pathConfiguration.properties("custom-app://feature")).isNotNull
+    }
+
+    @Test
     fun customProperties() {
         assertThat((pathConfiguration.properties("$url/custom/tabs").getTabs()?.size)).isEqualTo(1)
         assertThat((pathConfiguration.properties("$url/custom/tabs").getTabs()?.first()?.label)).isEqualTo("Tab 1")


### PR DESCRIPTION
Tapping a `mailto:`, `tel:` or custom-scheme link crashes with `MalformedURLException: unknown protocol`.    


Since cb80529 (#203), `Navigator.getRouteDecision()` eagerly resolves path-config properties for the proposed location, and `PathConfigurationData.path()` parses it with `java.net.URL`. But only supports http, so it throws before any `RouteDecisionHandler` runs.  

Reproduce: Click on a `<a href="mailto:me@domain.com">me@domain.com</a>` link.

Verified in the Demo app. 1.2.8 works and 1.3.0 crashes. This PR would fix it. 