### PR TITLE
Only reload the WebView on a cold boot visit when it's already on the visit location

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -662,9 +662,10 @@ class Session(
         // sees a WebView.loadUrl() request as a same-page visit instead of
         // requesting a full page reload. To work around this, we call
         // WebView.reload(), which fully reloads the page for all URLs.
-        when (visit.reload) {
-            true -> webView.reload()
-            else -> webView.loadUrl(visit.location)
+        if (visit.reload && webView.url == visit.location) {
+            webView.reload()
+        } else {
+            webView.loadUrl(visit.location)
         }
     }
 

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/session/SessionTest.kt
@@ -267,6 +267,25 @@ class SessionTest : BaseRepositoryTest() {
     }
 
     @Test
+    fun `cold boot visit with reload reloads the web view when it is on the visit location`() {
+        whenever(webView.url).thenReturn(visit.location)
+
+        session.visit(visit.copy(reload = true))
+
+        verify(webView).reload()
+    }
+
+    @Test
+    fun `cold boot visit with reload loads the visit location when the web view is on a different location`() {
+        whenever(webView.url).thenReturn("${visit.location}/modal")
+
+        session.visit(visit.copy(reload = true))
+
+        verify(webView, never()).reload()
+        verify(webView).loadUrl(visit.location)
+    }
+
+    @Test
     fun `restore current visit`() {
         val visitIdentifier = "12345"
         val restorationIdentifier = "67890"


### PR DESCRIPTION
### Symptoms

When a form inside a `modal` context screen is submitted and the server responds with `refresh_or_redirect_to` (a redirect to `/refresh_historical_location`), the modal is dismissed — but intermittently the screen behind it ends up rendering the *modal's* page instead of its own. For example, posting a comment from a modal composer screen sometimes leaves the underlying screen showing a fresh, empty composer form (with the underlying screen's toolbar), even though the comment was created successfully. Navigating back reveals the parent page with the submitted content.

### Root cause

Dismissing a modal with a `REFRESH` modal result triggers two concurrent operations on the shared WebView from the underlying destination's `onStartAfterModalResult`:

1. `HotwireWebFragmentDelegate.onStartAfterModalResult()` → `initNavigationVisit()` → a `RESTORE` visit to the destination's location (turbo.js updates the WebView's history asynchronously), and
2. `HotwireFragmentDelegate.onStartAfterModalResult()` → routes the modal result → `NavigatorMode.REFRESH` → `refresh()` → `session.reset()` + a cold boot visit with `reload: true`, which calls `WebView.reload()` in `Session.visitLocationAsColdBoot()`.

These race. When the cold boot runs before the restore visit has changed the WebView's history, the WebView's current page is still the dismissed modal's page — so `WebView.reload()` re-loads the modal's URL instead of the destination's location. The session then treats the cold boot as completed for the destination's location while the WebView actually renders the modal's page.

Debug log from a failing run (message screen behind a dismissed comment composer modal):

```
visitLocationAsColdBoot ... [location: https://example.com/buckets/1/messages/2]
onPageStarted ............. [location: https://example.com/buckets/1/recordings/2/comments/new]
```

### Fix

`WebView.reload()` exists to handle same-page visits for URLs with anchors (see the comment above the change). That only applies when the WebView is already on the visit location. Guard the `reload()` call accordingly and load the visit location directly otherwise:

```kotlin
if (visit.reload && webView.url == visit.location) {
    webView.reload()
} else {
    webView.loadUrl(visit.location)
}
```

### Testing

- Added two unit tests covering both branches of the cold boot reload.
- Verified in a Hotwire Native app against the failing scenario: with the fix, the same race ordering now loads the destination's location (`onPageStarted` reports the underlying screen's URL) and the modal flow behaves correctly — modal closes, underlying screen refreshes with the submitted content. Exercised repeatedly via modal form submissions ending in `refresh_or_redirect_to`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)