### PR TITLE
Don't forward credentials when the verification fetch encounters a cross-origin redirect

### DIFF
--- a/core/src/main/kotlin/dev/hotwire/core/turbo/http/HttpRepository.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/http/HttpRepository.kt
@@ -3,7 +3,8 @@ package dev.hotwire.core.turbo.http
 import dev.hotwire.core.logging.logError
 import dev.hotwire.core.turbo.util.dispatcherProvider
 import kotlinx.coroutines.withContext
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
 
@@ -24,16 +25,9 @@ internal class HttpRepository {
             val response = issueRequest(location)
 
             if (response != null) {
-                // Determine if there was a redirect, based on the final response's request url
-                val responseUrl = response.request.url
-                val isRedirect = location != responseUrl.toString()
-
                 HttpRequestResult(
                     response = response,
-                    redirect = if (!isRedirect) null else HttpRedirect(
-                        location = responseUrl.toString(),
-                        isCrossOrigin = location.toHttpUrl().host != responseUrl.host
-                    )
+                    redirect = redirectFrom(response)
                 )
             } else {
                 null
@@ -41,10 +35,33 @@ internal class HttpRepository {
         }
     }
 
+    /**
+     * Inspects a response for a redirect and, when present, resolves the destination and whether
+     * it is cross-origin.
+     *
+     * The verification request deliberately does not follow redirects (see [verificationClient]),
+     * so the destination is determined solely from the `Location` header of the first response.
+     * This guarantees no credentials (e.g. `Cookie`, `Authorization`) are ever forwarded to a
+     * cross-origin redirect destination, while still giving the caller everything it needs to
+     * detect and propose a cross-origin redirect visit.
+     */
+    private fun redirectFrom(response: Response): HttpRedirect? {
+        if (!response.isRedirect) return null
+
+        val locationHeader = response.header("Location") ?: return null
+        val requestUrl = response.request.url
+        val redirectUrl = requestUrl.resolve(locationHeader) ?: return null
+
+        return HttpRedirect(
+            location = redirectUrl.toString(),
+            isCrossOrigin = !redirectUrl.isSameOriginAs(requestUrl)
+        )
+    }
+
     private fun issueRequest(location: String): Response? {
         return try {
             val request = buildRequest(location)
-            HotwireHttpClient.instance.newCall(request).execute()
+            verificationClient().newCall(request).execute()
         } catch (e: Exception) {
             logError("httpRequestError", e)
             null
@@ -54,4 +71,26 @@ internal class HttpRepository {
     private fun buildRequest(location: String): Request {
         return Request.Builder().url(location).build()
     }
+
+    /**
+     * A client dedicated to the native redirect-verification fetch, derived from the shared
+     * client so it inherits its cache, timeouts, and interceptors. Redirects are disabled so a
+     * cross-origin redirect can be detected from the `Location` header without ever sending the
+     * credential-bearing request (`Cookie`/`Authorization`) on to the redirect destination.
+     */
+    private fun verificationClient(): OkHttpClient {
+        return HotwireHttpClient.instance.newBuilder()
+            .followRedirects(false)
+            .followSslRedirects(false)
+            .build()
+    }
+}
+
+/**
+ * Two URLs share an origin only when their scheme, host, and (effective) port all match. Comparing
+ * the full origin — not just the host — ensures a scheme downgrade (e.g. https → http) or a port
+ * change is correctly treated as cross-origin.
+ */
+private fun HttpUrl.isSameOriginAs(other: HttpUrl): Boolean {
+    return scheme == other.scheme && host == other.host && port == other.port
 }

--- a/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
+++ b/core/src/main/kotlin/dev/hotwire/core/turbo/session/Session.kt
@@ -390,8 +390,10 @@ class Session(
         activity.lifecycleScope.launch {
             val result = httpRepository.fetch(location)
 
-            if (result != null && result.response.isSuccessful &&
-                result.redirect?.isCrossOrigin == true) {
+            // The verification fetch does not follow redirects, so a cross-origin redirect is
+            // reported as an unfollowed 3xx response. Detecting one is sufficient to propose the
+            // cross-origin redirect visit; credentials are never forwarded to the destination.
+            if (result != null && result.redirect?.isCrossOrigin == true) {
                 visitProposedToCrossOriginRedirect(
                     location = location,
                     redirectLocation = result.redirect.location,

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/BaseRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/BaseRepositoryTest.kt
@@ -1,6 +1,7 @@
 package dev.hotwire.core.turbo
 
 import dev.hotwire.core.turbo.http.HotwireHttpClient
+import dev.hotwire.core.turbo.http.WebViewCookieJar
 import dev.hotwire.core.turbo.util.dispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,6 +64,7 @@ open class BaseRepositoryTest : BaseUnitTest() {
 
     private fun client(): OkHttpClient {
         return OkHttpClient.Builder()
+            .cookieJar(WebViewCookieJar())
             .dispatcher(Dispatcher(SynchronousExecutorService()))
             .build()
     }

--- a/core/src/test/kotlin/dev/hotwire/core/turbo/http/HttpRepositoryTest.kt
+++ b/core/src/test/kotlin/dev/hotwire/core/turbo/http/HttpRepositoryTest.kt
@@ -1,0 +1,109 @@
+package dev.hotwire.core.turbo.http
+
+import android.os.Build
+import android.webkit.CookieManager
+import dev.hotwire.core.turbo.BaseRepositoryTest
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@ExperimentalCoroutinesApi
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.R])
+class HttpRepositoryTest : BaseRepositoryTest() {
+    private val repository = HttpRepository()
+    private val crossOriginServer = MockWebServer()
+
+    override fun setup() {
+        super.setup()
+        crossOriginServer.start()
+        seedSessionCookie()
+    }
+
+    override fun teardown() {
+        super.teardown()
+        crossOriginServer.shutdown()
+        CookieManager.getInstance().removeAllCookies(null)
+    }
+
+    @Test
+    fun `does not forward credentials to a cross-origin redirect destination`() {
+        val crossOriginUrl = crossOriginServer.url("/attacker").toString()
+
+        // First-party origin issues a redirect to a cross-origin destination.
+        server.enqueue(redirectResponse(crossOriginUrl))
+        // If a credential-bearing request were (incorrectly) followed to the destination, it would
+        // land here. It must never be reached.
+        crossOriginServer.enqueue(MockResponse().setResponseCode(200))
+
+        val result = runBlocking { repository.fetch(baseUrl()) }
+
+        // Security invariant: the cross-origin destination received no request at all, so no
+        // Cookie or other credential could possibly have leaked to it.
+        assertThat(crossOriginServer.requestCount).isEqualTo(0)
+
+        // The credentialed request was sent only to the first-party origin.
+        val firstPartyRequest = server.takeRequest()
+        assertThat(firstPartyRequest.headers["Cookie"]).contains("session=test-cookie")
+
+        // The caller still gets what it needs: the cross-origin redirect is detected (without
+        // following it) so it can propose the cross-origin redirect visit.
+        assertThat(result).isNotNull
+        assertThat(result!!.redirect).isNotNull
+        assertThat(result.redirect!!.isCrossOrigin).isTrue
+        assertThat(result.redirect.location).isEqualTo(crossOriginUrl)
+    }
+
+    @Test
+    fun `detects a same-origin redirect without flagging it cross-origin`() {
+        server.enqueue(redirectResponse(server.url("/redirected").toString()))
+
+        val result = runBlocking { repository.fetch(baseUrl()) }
+
+        assertThat(result).isNotNull
+        assertThat(result!!.redirect).isNotNull
+        assertThat(result.redirect!!.isCrossOrigin).isFalse
+
+        // The redirect is not followed, so the same-origin destination is not fetched.
+        assertThat(server.requestCount).isEqualTo(1)
+    }
+
+    @Test
+    fun `resolves a relative redirect location against the request origin as same-origin`() {
+        server.enqueue(redirectResponse("/relative/path"))
+
+        val result = runBlocking { repository.fetch(baseUrl()) }
+
+        assertThat(result).isNotNull
+        assertThat(result!!.redirect).isNotNull
+        assertThat(result.redirect!!.isCrossOrigin).isFalse
+        assertThat(result.redirect.location).isEqualTo(server.url("/relative/path").toString())
+    }
+
+    @Test
+    fun `reports no redirect for a direct successful response`() {
+        server.enqueue(MockResponse().setResponseCode(200))
+
+        val result = runBlocking { repository.fetch(baseUrl()) }
+
+        assertThat(result).isNotNull
+        assertThat(result!!.response.isSuccessful).isTrue
+        assertThat(result.redirect).isNull()
+    }
+
+    private fun redirectResponse(location: String): MockResponse {
+        return MockResponse()
+            .setResponseCode(302)
+            .addHeader("Location", location)
+    }
+
+    private fun seedSessionCookie() {
+        CookieManager.getInstance().setCookie(baseUrl(), "session=test-cookie")
+    }
+}


### PR DESCRIPTION
## Summary

The native redirect-verification fetch in `HttpRepository` attaches the WebView's cookies to the request as a static `Cookie` header and then issues it with a client that follows redirects. When the requested URL responds with a **cross-origin redirect**, OkHttp forwards that manually-set `Cookie` header to the redirect destination — delivering first-party session cookies to a different origin. (OkHttp drops the `Authorization` header when a redirect changes host, but it does **not** drop a caller-set `Cookie` header.)

This fetch only needs to *detect* whether the response is a cross-origin redirect; it never needs to follow that redirect with credentials. This change stops following redirects on the verification fetch and inspects the `Location` header directly, so no credential-bearing request is ever sent to a redirect destination.

## Changes

- **Don't follow redirects on the verification fetch.** Its client is now derived from the shared client (keeping its cache, timeouts, and interceptors) with `followRedirects(false)` / `followSslRedirects(false)`.
- **Resolve the destination from `Location`.** The redirect target is computed by resolving the `Location` header against the request URL, so relative, protocol-relative, and absolute locations are all handled correctly.
- **Compare full origin, not just host.** A redirect is treated as cross-origin when scheme, host, **or** port differ — so an HTTPS→HTTP downgrade or a port change is correctly detected as cross-origin.
- **Caller.** `Session.visitRequestFailedWithNonHttpStatusCode` previously gated on `response.isSuccessful`, which only held when redirects were followed through to a 2xx. Since the verification fetch no longer follows redirects, the response is the unfollowed 3xx; detecting a cross-origin redirect is now sufficient to propose the cross-origin redirect visit.

Only the first redirect hop is inspected — sufficient to detect a direct cross-origin redirect. Deeper same-origin chains that would eventually cross origin now fail closed (the visit fails) rather than being followed with credentials.

## Testing

Adds `HttpRepositoryTest` (MockWebServer):

- A cross-origin redirect is detected and its destination receives **no request at all** — so no `Cookie` or other credential can reach it — while the first-party request still carries its cookies.
- A same-origin redirect is detected and correctly not flagged cross-origin.
- A relative `Location` resolves against the request origin (same-origin).
- A direct 2xx response reports no redirect.

Scope run locally: `./gradlew :core:testDebugUnitTest` (core module unit tests).
